### PR TITLE
Update Set-TssSecretField.ps1 Path parameter Validation

### DIFF
--- a/src/functions/secrets/Set-TssSecretField.ps1
+++ b/src/functions/secrets/Set-TssSecretField.ps1
@@ -89,7 +89,7 @@ function Set-TssSecretField {
         # Path of file to attach to field
         [Parameter(ParameterSetName = 'io')]
         [ValidateScript( {
-                if (-not (Test-Path $_ -PathType Container)) {
+                if (Test-Path $_ -PathType Container) {
                     throw "Path [$_] is a directory, provide full file path"
                 } else {
                     $true


### PR DESCRIPTION
Upload of file was not possible. The Path parameter Validation was incorrect, complaining for directory while file was passed.