### PR TITLE
Fixes #271 - Unable to convert value to Thycotic.PowerShell.Secrets.Summary

### DIFF
--- a/src/Thycotic.SecretServer/classes/secrets/Summary.cs
+++ b/src/Thycotic.SecretServer/classes/secrets/Summary.cs
@@ -17,6 +17,7 @@ namespace Thycotic.PowerShell.Secrets
         public bool DoubleLockEnabled { get; set; }
         public SummaryExtendedField[] ExtendedFields { get; set; }
         public int FolderId { get; set; }
+        public bool HasLauncher { get; set; }
         public bool HidePassword { get; set; }
         public int Id { get; set; }
         public bool InheritsPermissions { get; set; }


### PR DESCRIPTION
Version 11.2 added the field hasLauncher to the Secret Summary data that's returned from the API.  This is causing the Search-TssSecret to fail completely (and probably some others). 

Fixes #271