### PR TITLE
Added missing class properties. Fixes #288

### DIFF
--- a/src/Thycotic.SecretServer.psd1
+++ b/src/Thycotic.SecretServer.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Thycotic.SecretServer.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.60.7'
+ModuleVersion = '0.60.8'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'

--- a/src/Thycotic.SecretServer/classes/groups/Summary.cs
+++ b/src/Thycotic.SecretServer/classes/groups/Summary.cs
@@ -17,5 +17,6 @@ namespace Thycotic.PowerShell.Groups
         public string Name { get; set; }
         public bool Synchronized { get; set; }
         public bool SynchronizeNow { get; set; }
+        public bool isPlatform { get; set; }
     }
 }

--- a/src/Thycotic.SecretServer/classes/roles/Role.cs
+++ b/src/Thycotic.SecretServer/classes/roles/Role.cs
@@ -11,5 +11,6 @@ namespace Thycotic.PowerShell.Roles
         public bool Enabled { get; set; }
         public int Id { get; set; }
         public string Name { get; set; }
+        public bool isSystem { get; set; }
     }
 }

--- a/src/Thycotic.SecretServer/classes/secret-dependencies/Summary.cs
+++ b/src/Thycotic.SecretServer/classes/secret-dependencies/Summary.cs
@@ -17,5 +17,6 @@ namespace Thycotic.PowerShell.SecretDependencies
         public string ServiceName { get; set; }
         public int TypeId { get; set; }
         public string TypeName { get; set; }
+        public bool canTest { get; set; }
     }
 }

--- a/src/Thycotic.SecretServer/classes/users/Summary.cs
+++ b/src/Thycotic.SecretServer/classes/users/Summary.cs
@@ -21,5 +21,6 @@ namespace Thycotic.PowerShell.Users
         public int LoginFailures { get; set; }
         public string Username { get; set; }
         public string TwoFactorMethod { get; set; }
+        public string platformIntegrationType { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds missing class properties to enable the effective marshaling of the REST API data into its corresponding `c#` classes.

This fixes #288.

All PowerShell cmdlets mentioned in the above issue have been manually tested against a cloud secret server instance. No additional unit tests fail as a result of this PR. 