### PR TITLE
Missing path ParameterSetName on Id

### DIFF
--- a/src/functions/secrets/Get-TssSecretAttachment.ps1
+++ b/src/functions/secrets/Get-TssSecretAttachment.ps1
@@ -32,6 +32,7 @@ function Get-TssSecretAttachment {
 
         # Secret ID
         [Parameter(Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = 'id')]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = 'path')]
         [Alias('SecretId')]
         [int[]]
         $Id,


### PR DESCRIPTION
Added Path as ParameterSetName to the id field to allow exporting specific file.