### PR TITLE
Fix the code to pass the Body param in proper way after migration to .net 6

### DIFF
--- a/src/Thycotic.SecretServer/cmdlets/private/InvokeTssApiCmdlet.cs
+++ b/src/Thycotic.SecretServer/cmdlets/private/InvokeTssApiCmdlet.cs
@@ -93,7 +93,7 @@ namespace Thycotic.SecretServer.Cmdlets
 			Uri requestUri = new Uri(Uri);
 			options.BaseUrl = requestUri;
 			options.MaxTimeout = Timeout;
-
+            
 			if (MyInvocation.BoundParameters.ContainsKey("Proxy"))
             {
 				options.Proxy = new WebProxy(Proxy);
@@ -119,14 +119,14 @@ namespace Thycotic.SecretServer.Cmdlets
 			}
             if (MyInvocation.BoundParameters.ContainsKey("Body"))
             {
-                apiRequest.AddParameter(ContentType, Body, ParameterType.RequestBody);
+				apiRequest.AddParameter(ContentType, ((PSObject)Body).BaseObject, ParameterType.RequestBody);
             }
 			var apiClient = new RestClient(options);
 			if (!String.IsNullOrEmpty(OutFile))
             {
                 // stream file content out
                 RestResponse apiResponse = apiClient.Execute(apiRequest);
-                File.WriteAllBytes(OutFile, apiResponse.RawBytes);
+				File.WriteAllBytes(OutFile, apiResponse.RawBytes);
             }
             else
             {

--- a/src/functions/metadata/New-TssMetadataField.ps1
+++ b/src/functions/metadata/New-TssMetadataField.ps1
@@ -157,7 +157,11 @@ function New-TssMetadataField {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Metadata.Field]$restResponse
+                $restResponse | ForEach-Object {
+                    $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
+                    $_ | Select-Object -Property $NonEmptyProperties
+                }
+                [Thycotic.PowerShell.Metadata.Field]$NonEmptyProperties
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/Update-TssMetadataField.ps1
+++ b/src/functions/metadata/Update-TssMetadataField.ps1
@@ -133,7 +133,11 @@ function Update-TssMetadataField {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Metadata.Field]$restResponse
+                    $restResponse | ForEach-Object {
+                        $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
+                        $_ | Select-Object -Property $NonEmptyProperties
+                    }
+                    [Thycotic.PowerShell.Metadata.Field]$NonEmptyProperties
                 }
             }
         } else {


### PR DESCRIPTION
1. Ignore the null values from the response
2. Fix the code to pass the Body param in proper way after migration to .net 6
3.Fix the bug #352 and #353 