### PR TITLE
Update Permission.cs

### DIFF
--- a/src/Thycotic.SecretServer/classes/secret-permissions/Permission.cs
+++ b/src/Thycotic.SecretServer/classes/secret-permissions/Permission.cs
@@ -7,6 +7,7 @@ namespace Thycotic.PowerShell.SecretPermissions
 {
     public class Permission
     {
+        public string DomainName { get; set; }
         public int GroupId { get; set; }
         public string GroupName { get; set; }
         public int Id { get; set; }


### PR DESCRIPTION
Fixes #365  Added additional item to Permission class.
When running `Search-TSSSecretPermission`, the rest response includes an additional property (DomainName) that isn't part of the current SecretPermissions class, and therefore the command errors out as it can't convert value of type "System.Management.Automation.PSCustomObject" to type "Thycotic.PowerShell.SecretPermissions.Permission"