### PR TITLE
Find-TssSecret: Fixed IncludeInactive switch

### DIFF
--- a/src/functions/secrets/Find-TssSecret.ps1
+++ b/src/functions/secrets/Find-TssSecret.ps1
@@ -239,6 +239,7 @@ function Find-TssSecret {
                     'RpcEnabled' { $filters += "filter.onlyRPCEnabled=$([boolean]$RpcEnabled)" }
                     'SharedWithMe' { $filters += "filter.onlySharedWithMe=$([boolean]$SharedWithMe)" }
                     'ExcludeDoubleLock' { $filters += "filter.allowDoubleLocks=$([boolean]$ExcludeDoubleLock)" }
+                    'IncludeInactive' { $filters += "filter.includeInactive=$([boolean]$IncludeInactive)" }
                     'ExcludeActive' { $filters += "filter.includeActive=$([boolean]$ExcludeActive)" }
                     'Scope' {
                         $filters += switch ($tssParams['Scope']) {


### PR DESCRIPTION
`Find-TssSecret` - Added missing includeInactive filter and `IncludeInactive` parameter works now - Fixed #415 