### PR TITLE
updated rest response handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ src/bin/Thycotic.SecretServer.deps.json
 src/bin/Thycotic.SecretServer.xml
 src/bin/Thycotic.SecretServer.pdb
 src/bin/*.dll
+src/bin/runtimes/
 
 # in case you use Carter's WikiLens
 Daily/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ release*
 .vs/
 .claude/*
 .calude
-
+thycotic.secretserver.sln
 # ignoring doc works for now
 /docs/_site
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.[Ll]og
 release*
 .vs/
+.claude/*
+.calude
 
 # ignoring doc works for now
 /docs/_site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased -- 2021-xx-xx
+## 0.62.0 -- Unreleased
 
 ### Breaking Changes
 
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-* None
+* REST response handling: all functions now strip unknown properties from API responses before casting to typed objects, preventing `Cannot convert value` errors when Secret Server Cloud adds new response fields not yet reflected in module class definitions. Unknown properties are reported via `Write-Verbose`. Fixes #392, #398, #400, #406, #407, #408, #409, #410, #419.
 
 ### New Stuff
 
-* None
+* `FilterTssResponse` parts utility — centralised helper called by all functions to filter and verbose-log unknown response properties before type cast.
 
 ### General Updates
 

--- a/src/Thycotic.SecretServer.psd1
+++ b/src/Thycotic.SecretServer.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Thycotic.SecretServer.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.61.8'
+ModuleVersion = '0.62.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'

--- a/src/functions/configurations/Get-TssConfiguration.ps1
+++ b/src/functions/configurations/Get-TssConfiguration.ps1
@@ -77,40 +77,31 @@ function Get-TssConfiguration {
             if ($restResponse) {
                 switch ($Type) {
                     'All' {
-                        $typeProps = [Thycotic.PowerShell.Configuration.General].GetProperties().Name
-                        [Thycotic.PowerShell.Configuration.General]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Configuration.General](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.General]))
                     }
                     'Application' {
-                        $typeProps = [Thycotic.PowerShell.Configuration.ApplicationSettings].GetProperties().Name
-                        [Thycotic.PowerShell.Configuration.ApplicationSettings]($restResponse.applicationSettings | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Configuration.ApplicationSettings](. $FilterTssResponse $restResponse.applicationSettings ([Thycotic.PowerShell.Configuration.ApplicationSettings]))
                     }
                     'Email' {
-                        $typeProps = [Thycotic.PowerShell.Configuration.EmailSettings].GetProperties().Name
-                        [Thycotic.PowerShell.Configuration.EmailSettings]($restResponse.emailSettings | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Configuration.EmailSettings](. $FilterTssResponse $restResponse.emailSettings ([Thycotic.PowerShell.Configuration.EmailSettings]))
                     }
                     'Folders' {
-                        $typeProps = [Thycotic.PowerShell.Configuration.Folders].GetProperties().Name
-                        [Thycotic.PowerShell.Configuration.Folders]($restResponse.folders | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Configuration.Folders](. $FilterTssResponse $restResponse.folders ([Thycotic.PowerShell.Configuration.Folders]))
                     }
                     'Launcher' {
-                        $typeProps = [Thycotic.PowerShell.Configuration.LauncherSettings].GetProperties().Name
-                        [Thycotic.PowerShell.Configuration.LauncherSettings]($restResponse.launcherSettings | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Configuration.LauncherSettings](. $FilterTssResponse $restResponse.launcherSettings ([Thycotic.PowerShell.Configuration.LauncherSettings]))
                     }
                     'LocalUserPasswords' {
-                        $typeProps = [Thycotic.PowerShell.Configuration.LocalUserPasswords].GetProperties().Name
-                        [Thycotic.PowerShell.Configuration.LocalUserPasswords]($restResponse.localUserPasswords | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Configuration.LocalUserPasswords](. $FilterTssResponse $restResponse.localUserPasswords ([Thycotic.PowerShell.Configuration.LocalUserPasswords]))
                     }
                     'PermissionOptions' {
-                        $typeProps = [Thycotic.PowerShell.Configuration.PermissionOptions].GetProperties().Name
-                        [Thycotic.PowerShell.Configuration.PermissionOptions]($restResponse.permissionOptions | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Configuration.PermissionOptions](. $FilterTssResponse $restResponse.permissionOptions ([Thycotic.PowerShell.Configuration.PermissionOptions]))
                     }
                     'UserExperience' {
-                        $typeProps = [Thycotic.PowerShell.Configuration.UserExperience].GetProperties().Name
-                        [Thycotic.PowerShell.Configuration.UserExperience]($restResponse.userExperience | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Configuration.UserExperience](. $FilterTssResponse $restResponse.userExperience ([Thycotic.PowerShell.Configuration.UserExperience]))
                     }
                     'UserInterface' {
-                        $typeProps = [Thycotic.PowerShell.Configuration.UserInterface].GetProperties().Name
-                        [Thycotic.PowerShell.Configuration.UserInterface]($restResponse.userInterface | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Configuration.UserInterface](. $FilterTssResponse $restResponse.userInterface ([Thycotic.PowerShell.Configuration.UserInterface]))
                     }
                 }
             }

--- a/src/functions/configurations/Get-TssConfiguration.ps1
+++ b/src/functions/configurations/Get-TssConfiguration.ps1
@@ -76,15 +76,42 @@ function Get-TssConfiguration {
 
             if ($restResponse) {
                 switch ($Type) {
-                    'All' { [Thycotic.PowerShell.Configuration.General]$restResponse }
-                    'Application' { [Thycotic.PowerShell.Configuration.ApplicationSettings]$restResponse.applicationSettings }
-                    'Email' { [Thycotic.PowerShell.Configuration.EmailSettings]$restResponse.emailSettings }
-                    'Folders' { [Thycotic.PowerShell.Configuration.Folders]$restResponse.folders }
-                    'Launcher' { [Thycotic.PowerShell.Configuration.LauncherSettings]$restResponse.launcherSettings }
-                    'LocalUserPasswords' { [Thycotic.PowerShell.Configuration.LocalUserPasswords]$restResponse.localUserPasswords }
-                    'PermissionOptions' { [Thycotic.PowerShell.Configuration.PermissionOptions]$restResponse.permissionOptions }
-                    'UserExperience' { [Thycotic.PowerShell.Configuration.UserExperience]$restResponse.userExperience }
-                    'UserInterface' { [Thycotic.PowerShell.Configuration.UserInterface]$restResponse.userInterface }
+                    'All' {
+                        $typeProps = [Thycotic.PowerShell.Configuration.General].GetProperties().Name
+                        [Thycotic.PowerShell.Configuration.General]($restResponse | Select-Object -Property $typeProps)
+                    }
+                    'Application' {
+                        $typeProps = [Thycotic.PowerShell.Configuration.ApplicationSettings].GetProperties().Name
+                        [Thycotic.PowerShell.Configuration.ApplicationSettings]($restResponse.applicationSettings | Select-Object -Property $typeProps)
+                    }
+                    'Email' {
+                        $typeProps = [Thycotic.PowerShell.Configuration.EmailSettings].GetProperties().Name
+                        [Thycotic.PowerShell.Configuration.EmailSettings]($restResponse.emailSettings | Select-Object -Property $typeProps)
+                    }
+                    'Folders' {
+                        $typeProps = [Thycotic.PowerShell.Configuration.Folders].GetProperties().Name
+                        [Thycotic.PowerShell.Configuration.Folders]($restResponse.folders | Select-Object -Property $typeProps)
+                    }
+                    'Launcher' {
+                        $typeProps = [Thycotic.PowerShell.Configuration.LauncherSettings].GetProperties().Name
+                        [Thycotic.PowerShell.Configuration.LauncherSettings]($restResponse.launcherSettings | Select-Object -Property $typeProps)
+                    }
+                    'LocalUserPasswords' {
+                        $typeProps = [Thycotic.PowerShell.Configuration.LocalUserPasswords].GetProperties().Name
+                        [Thycotic.PowerShell.Configuration.LocalUserPasswords]($restResponse.localUserPasswords | Select-Object -Property $typeProps)
+                    }
+                    'PermissionOptions' {
+                        $typeProps = [Thycotic.PowerShell.Configuration.PermissionOptions].GetProperties().Name
+                        [Thycotic.PowerShell.Configuration.PermissionOptions]($restResponse.permissionOptions | Select-Object -Property $typeProps)
+                    }
+                    'UserExperience' {
+                        $typeProps = [Thycotic.PowerShell.Configuration.UserExperience].GetProperties().Name
+                        [Thycotic.PowerShell.Configuration.UserExperience]($restResponse.userExperience | Select-Object -Property $typeProps)
+                    }
+                    'UserInterface' {
+                        $typeProps = [Thycotic.PowerShell.Configuration.UserInterface].GetProperties().Name
+                        [Thycotic.PowerShell.Configuration.UserInterface]($restResponse.userInterface | Select-Object -Property $typeProps)
+                    }
                 }
             }
         } else {

--- a/src/functions/configurations/Get-TssConfigurationAutoExport.ps1
+++ b/src/functions/configurations/Get-TssConfigurationAutoExport.ps1
@@ -53,8 +53,7 @@ function Get-TssConfigurationAutoExport {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Configuration.AutomaticExport].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.AutomaticExport]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.AutomaticExport](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.AutomaticExport]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationAutoExport.ps1
+++ b/src/functions/configurations/Get-TssConfigurationAutoExport.ps1
@@ -53,7 +53,8 @@ function Get-TssConfigurationAutoExport {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Configuration.AutomaticExport]$restResponse
+                $typeProps = [Thycotic.PowerShell.Configuration.AutomaticExport].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.AutomaticExport]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationBackup.ps1
+++ b/src/functions/configurations/Get-TssConfigurationBackup.ps1
@@ -52,7 +52,8 @@ function Get-TssConfigurationBackup {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Configuration.Backup]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Configuration.Backup].GetProperties().Name
+                    [Thycotic.PowerShell.Configuration.Backup]($restResponse | Select-Object -Property $typeProps)
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationBackup.ps1
+++ b/src/functions/configurations/Get-TssConfigurationBackup.ps1
@@ -52,8 +52,7 @@ function Get-TssConfigurationBackup {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Configuration.Backup].GetProperties().Name
-                    [Thycotic.PowerShell.Configuration.Backup]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Configuration.Backup](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.Backup]))
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationLocalUserPassword.ps1
+++ b/src/functions/configurations/Get-TssConfigurationLocalUserPassword.ps1
@@ -52,8 +52,7 @@ function Get-TssConfigurationLocalUserPassword {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Configuration.LocalUserPasswords].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.LocalUserPasswords]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.LocalUserPasswords](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.LocalUserPasswords]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationLocalUserPassword.ps1
+++ b/src/functions/configurations/Get-TssConfigurationLocalUserPassword.ps1
@@ -52,7 +52,8 @@ function Get-TssConfigurationLocalUserPassword {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Configuration.LocalUserPasswords]$restResponse
+                $typeProps = [Thycotic.PowerShell.Configuration.LocalUserPasswords].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.LocalUserPasswords]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationLogin.ps1
+++ b/src/functions/configurations/Get-TssConfigurationLogin.ps1
@@ -52,7 +52,8 @@ function Get-TssConfigurationLogin {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Configuration.Login]$restResponse
+                $typeProps = [Thycotic.PowerShell.Configuration.Login].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.Login]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationLogin.ps1
+++ b/src/functions/configurations/Get-TssConfigurationLogin.ps1
@@ -52,8 +52,7 @@ function Get-TssConfigurationLogin {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Configuration.Login].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.Login]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.Login](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.Login]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationRpc.ps1
+++ b/src/functions/configurations/Get-TssConfigurationRpc.ps1
@@ -52,8 +52,7 @@ function Get-TssConfigurationRpc {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Configuration.Rpc].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.Rpc]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.Rpc](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.Rpc]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationRpc.ps1
+++ b/src/functions/configurations/Get-TssConfigurationRpc.ps1
@@ -52,7 +52,8 @@ function Get-TssConfigurationRpc {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Configuration.Rpc]$restResponse
+                $typeProps = [Thycotic.PowerShell.Configuration.Rpc].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.Rpc]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationSaml.ps1
+++ b/src/functions/configurations/Get-TssConfigurationSaml.ps1
@@ -52,8 +52,7 @@ function Get-TssConfigurationSaml {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Configuration.Saml].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.Saml]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.Saml](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.Saml]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationSaml.ps1
+++ b/src/functions/configurations/Get-TssConfigurationSaml.ps1
@@ -52,7 +52,8 @@ function Get-TssConfigurationSaml {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Configuration.Saml]$restResponse
+                $typeProps = [Thycotic.PowerShell.Configuration.Saml].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.Saml]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationSearchIndex.ps1
+++ b/src/functions/configurations/Get-TssConfigurationSearchIndex.ps1
@@ -52,7 +52,8 @@ function Get-TssConfigurationSearchIndex {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Configuration.SearchIndexer]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Configuration.SearchIndexer].GetProperties().Name
+                    [Thycotic.PowerShell.Configuration.SearchIndexer]($restResponse.records | Select-Object -Property $typeProps)
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationSearchIndex.ps1
+++ b/src/functions/configurations/Get-TssConfigurationSearchIndex.ps1
@@ -52,8 +52,7 @@ function Get-TssConfigurationSearchIndex {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.Configuration.SearchIndexer].GetProperties().Name
-                    [Thycotic.PowerShell.Configuration.SearchIndexer]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Configuration.SearchIndexer](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Configuration.SearchIndexer]))
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationSecurity.ps1
+++ b/src/functions/configurations/Get-TssConfigurationSecurity.ps1
@@ -52,8 +52,7 @@ function Get-TssConfigurationSecurity {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Configuration.Security].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.Security]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.Security](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.Security]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationSecurity.ps1
+++ b/src/functions/configurations/Get-TssConfigurationSecurity.ps1
@@ -52,7 +52,8 @@ function Get-TssConfigurationSecurity {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Configuration.Security]$restResponse
+                $typeProps = [Thycotic.PowerShell.Configuration.Security].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.Security]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationSiteConnector.ps1
+++ b/src/functions/configurations/Get-TssConfigurationSiteConnector.ps1
@@ -57,7 +57,8 @@ function Get-TssConfigurationSiteConnector {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Configuration.SiteConnector[]]$restResponse
+                $typeProps = [Thycotic.PowerShell.Configuration.SiteConnector].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.SiteConnector[]]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Get-TssConfigurationSiteConnector.ps1
+++ b/src/functions/configurations/Get-TssConfigurationSiteConnector.ps1
@@ -57,8 +57,7 @@ function Get-TssConfigurationSiteConnector {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Configuration.SiteConnector].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.SiteConnector[]]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.SiteConnector[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.SiteConnector]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Search-TssAutoExportStorage.ps1
+++ b/src/functions/configurations/Search-TssAutoExportStorage.ps1
@@ -57,7 +57,8 @@ function Search-TssAutoExportStorage {
                 Write-Warning "No AutomaticStorage found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Configuration.AutomaticExportItem[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Configuration.AutomaticExportItem].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.AutomaticExportItem[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Search-TssAutoExportStorage.ps1
+++ b/src/functions/configurations/Search-TssAutoExportStorage.ps1
@@ -57,8 +57,7 @@ function Search-TssAutoExportStorage {
                 Write-Warning "No AutomaticStorage found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Configuration.AutomaticExportItem].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.AutomaticExportItem[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.AutomaticExportItem[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Configuration.AutomaticExportItem]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Search-TssConfigurationAudit.ps1
+++ b/src/functions/configurations/Search-TssConfigurationAudit.ps1
@@ -81,8 +81,7 @@ function Search-TssConfigurationAudit {
                 Write-Warning "No ConfigurationAudit found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Configuration.Audit].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.Audit[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.Audit[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Configuration.Audit]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Search-TssConfigurationAudit.ps1
+++ b/src/functions/configurations/Search-TssConfigurationAudit.ps1
@@ -81,7 +81,8 @@ function Search-TssConfigurationAudit {
                 Write-Warning "No ConfigurationAudit found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Configuration.Audit[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Configuration.Audit].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.Audit[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Search-TssConfigurationBackupLog.ps1
+++ b/src/functions/configurations/Search-TssConfigurationBackupLog.ps1
@@ -57,7 +57,8 @@ function Search-TssConfigurationBackupLog {
             }
 
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Configuration.DbBackupLog[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Configuration.DbBackupLog].GetProperties().Name
+                [Thycotic.PowerShell.Configuration.DbBackupLog[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/configurations/Search-TssConfigurationBackupLog.ps1
+++ b/src/functions/configurations/Search-TssConfigurationBackupLog.ps1
@@ -57,8 +57,7 @@ function Search-TssConfigurationBackupLog {
             }
 
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Configuration.DbBackupLog].GetProperties().Name
-                [Thycotic.PowerShell.Configuration.DbBackupLog[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Configuration.DbBackupLog[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Configuration.DbBackupLog]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/diagnostics/Get-TssDiagnostic.ps1
+++ b/src/functions/diagnostics/Get-TssDiagnostic.ps1
@@ -52,7 +52,8 @@ function Get-TssDiagnostic {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Diagnostics.Diagnostic]$restResponse
+                $typeProps = [Thycotic.PowerShell.Diagnostics.Diagnostic].GetProperties().Name
+                [Thycotic.PowerShell.Diagnostics.Diagnostic]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/diagnostics/Get-TssDiagnostic.ps1
+++ b/src/functions/diagnostics/Get-TssDiagnostic.ps1
@@ -52,8 +52,7 @@ function Get-TssDiagnostic {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Diagnostics.Diagnostic].GetProperties().Name
-                [Thycotic.PowerShell.Diagnostics.Diagnostic]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Diagnostics.Diagnostic](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Diagnostics.Diagnostic]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/diagnostics/Get-TssDiagnosticBackgroundProcess.ps1
+++ b/src/functions/diagnostics/Get-TssDiagnosticBackgroundProcess.ps1
@@ -52,8 +52,7 @@ function Get-TssDiagnosticBackgroundProcess {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Diagnostics.BackgroundProcess].GetProperties().Name
-                [Thycotic.PowerShell.Diagnostics.BackgroundProcess[]]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Diagnostics.BackgroundProcess[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Diagnostics.BackgroundProcess]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/diagnostics/Get-TssDiagnosticBackgroundProcess.ps1
+++ b/src/functions/diagnostics/Get-TssDiagnosticBackgroundProcess.ps1
@@ -52,7 +52,8 @@ function Get-TssDiagnosticBackgroundProcess {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Diagnostics.BackgroundProcess[]]$restResponse
+                $typeProps = [Thycotic.PowerShell.Diagnostics.BackgroundProcess].GetProperties().Name
+                [Thycotic.PowerShell.Diagnostics.BackgroundProcess[]]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/diagnostics/Search-TssSystemLog.ps1
+++ b/src/functions/diagnostics/Search-TssSystemLog.ps1
@@ -85,8 +85,7 @@ function Search-TssSystemLog {
                 Write-Warning "No messages found in the System Log"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Diagnostics.SystemLog].GetProperties().Name
-                [Thycotic.PowerShell.Diagnostics.SystemLog[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Diagnostics.SystemLog[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Diagnostics.SystemLog]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/diagnostics/Search-TssSystemLog.ps1
+++ b/src/functions/diagnostics/Search-TssSystemLog.ps1
@@ -85,7 +85,8 @@ function Search-TssSystemLog {
                 Write-Warning "No messages found in the System Log"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Diagnostics.SystemLog[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Diagnostics.SystemLog].GetProperties().Name
+                [Thycotic.PowerShell.Diagnostics.SystemLog[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/directory-services/Get-TssDirectoryServiceDomain.ps1
+++ b/src/functions/directory-services/Get-TssDirectoryServiceDomain.ps1
@@ -65,7 +65,8 @@ function Get-TssDirectoryServiceDomain {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.DirectoryServices.Domain[]]$restResponse
+                    $typeProps = [Thycotic.PowerShell.DirectoryServices.Domain].GetProperties().Name
+                    [Thycotic.PowerShell.DirectoryServices.Domain[]]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/directory-services/Get-TssDirectoryServiceDomain.ps1
+++ b/src/functions/directory-services/Get-TssDirectoryServiceDomain.ps1
@@ -65,8 +65,7 @@ function Get-TssDirectoryServiceDomain {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.DirectoryServices.Domain].GetProperties().Name
-                    [Thycotic.PowerShell.DirectoryServices.Domain[]]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.DirectoryServices.Domain[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.DirectoryServices.Domain]))
                 }
             }
         } else {

--- a/src/functions/directory-services/Get-TssDirectoryServiceSyncStatus.ps1
+++ b/src/functions/directory-services/Get-TssDirectoryServiceSyncStatus.ps1
@@ -52,11 +52,7 @@ function Get-TssDirectoryServiceSyncStatus {
                 }
 
                 if ($restResponse) {
-                    $restResponse | ForEach-Object {
-                        $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                        $_ | Select-Object -Property $NonEmptyProperties
-                    }
-                    [Thycotic.PowerShell.DirectoryServices.SyncStatus]$NonEmptyProperties
+                    [Thycotic.PowerShell.DirectoryServices.SyncStatus](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.DirectoryServices.SyncStatus]))
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/directory-services/New-TssDirectoryService.ps1
+++ b/src/functions/directory-services/New-TssDirectoryService.ps1
@@ -184,7 +184,8 @@ function New-TssDirectoryService {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.DirectoryServices.Domain]$restResponse
+                $typeProps = [Thycotic.PowerShell.DirectoryServices.Domain].GetProperties().Name
+                [Thycotic.PowerShell.DirectoryServices.Domain]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/directory-services/New-TssDirectoryService.ps1
+++ b/src/functions/directory-services/New-TssDirectoryService.ps1
@@ -184,8 +184,7 @@ function New-TssDirectoryService {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.DirectoryServices.Domain].GetProperties().Name
-                [Thycotic.PowerShell.DirectoryServices.Domain]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.DirectoryServices.Domain](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.DirectoryServices.Domain]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/directory-services/Search-TssDirectoryServiceDomain.ps1
+++ b/src/functions/directory-services/Search-TssDirectoryServiceDomain.ps1
@@ -81,7 +81,8 @@ function Search-TssDirectoryServiceDomain {
                 Write-Warning 'No Directory Domain found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.DirectoryServices.DomainSummary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.DirectoryServices.DomainSummary].GetProperties().Name
+                [Thycotic.PowerShell.DirectoryServices.DomainSummary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/directory-services/Search-TssDirectoryServiceDomain.ps1
+++ b/src/functions/directory-services/Search-TssDirectoryServiceDomain.ps1
@@ -81,8 +81,7 @@ function Search-TssDirectoryServiceDomain {
                 Write-Warning 'No Directory Domain found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.DirectoryServices.DomainSummary].GetProperties().Name
-                [Thycotic.PowerShell.DirectoryServices.DomainSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.DirectoryServices.DomainSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.DirectoryServices.DomainSummary]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/directory-services/Search-TssDirectoryServiceGroup.ps1
+++ b/src/functions/directory-services/Search-TssDirectoryServiceGroup.ps1
@@ -72,8 +72,7 @@ function Search-TssDirectoryServiceGroup {
                 Write-Warning "No Directory Service Group found"
             }
             if ($restResponse.groups) {
-                $typeProps = [Thycotic.PowerShell.DirectoryServices.Group].GetProperties().Name
-                [Thycotic.PowerShell.DirectoryServices.Group[]]($restResponse.groups | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.DirectoryServices.Group[]](. $FilterTssResponse $restResponse.groups ([Thycotic.PowerShell.DirectoryServices.Group]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/directory-services/Search-TssDirectoryServiceGroup.ps1
+++ b/src/functions/directory-services/Search-TssDirectoryServiceGroup.ps1
@@ -72,7 +72,8 @@ function Search-TssDirectoryServiceGroup {
                 Write-Warning "No Directory Service Group found"
             }
             if ($restResponse.groups) {
-                [Thycotic.PowerShell.DirectoryServices.Group[]]$restResponse.groups
+                $typeProps = [Thycotic.PowerShell.DirectoryServices.Group].GetProperties().Name
+                [Thycotic.PowerShell.DirectoryServices.Group[]]($restResponse.groups | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/directory-services/Search-TssDirectoryServiceGroupMember.ps1
+++ b/src/functions/directory-services/Search-TssDirectoryServiceGroupMember.ps1
@@ -67,7 +67,8 @@ function Search-TssDirectoryServiceGroupMember {
                 Write-Warning "No DirectoryServiceGroupMember found"
             }
             if ($restResponse.members) {
-                [Thycotic.PowerShell.DirectoryServices.GroupMember[]]$restResponse.members
+                $typeProps = [Thycotic.PowerShell.DirectoryServices.GroupMember].GetProperties().Name
+                [Thycotic.PowerShell.DirectoryServices.GroupMember[]]($restResponse.members | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/directory-services/Search-TssDirectoryServiceGroupMember.ps1
+++ b/src/functions/directory-services/Search-TssDirectoryServiceGroupMember.ps1
@@ -67,8 +67,7 @@ function Search-TssDirectoryServiceGroupMember {
                 Write-Warning "No DirectoryServiceGroupMember found"
             }
             if ($restResponse.members) {
-                $typeProps = [Thycotic.PowerShell.DirectoryServices.GroupMember].GetProperties().Name
-                [Thycotic.PowerShell.DirectoryServices.GroupMember[]]($restResponse.members | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.DirectoryServices.GroupMember[]](. $FilterTssResponse $restResponse.members ([Thycotic.PowerShell.DirectoryServices.GroupMember]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/distributed-engines/Get-TssDistributedEngineConfiguration.ps1
+++ b/src/functions/distributed-engines/Get-TssDistributedEngineConfiguration.ps1
@@ -52,8 +52,7 @@ function Get-TssDistributedEngineConfiguration {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.DistributedEngines.Configuration].GetProperties().Name
-                    [Thycotic.PowerShell.DistributedEngines.Configuration]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.DistributedEngines.Configuration](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.DistributedEngines.Configuration]))
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/distributed-engines/Get-TssDistributedEngineConfiguration.ps1
+++ b/src/functions/distributed-engines/Get-TssDistributedEngineConfiguration.ps1
@@ -52,7 +52,8 @@ function Get-TssDistributedEngineConfiguration {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.DistributedEngines.Configuration]$restResponse
+                    $typeProps = [Thycotic.PowerShell.DistributedEngines.Configuration].GetProperties().Name
+                    [Thycotic.PowerShell.DistributedEngines.Configuration]($restResponse | Select-Object -Property $typeProps)
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/distributed-engines/Get-TssDistributedEngineSite.ps1
+++ b/src/functions/distributed-engines/Get-TssDistributedEngineSite.ps1
@@ -59,7 +59,8 @@ function Get-TssDistributedEngineSite {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.DistributedEngines.Site]$restResponse
+                    $typeProps = [Thycotic.PowerShell.DistributedEngines.Site].GetProperties().Name
+                    [Thycotic.PowerShell.DistributedEngines.Site]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/distributed-engines/Get-TssDistributedEngineSite.ps1
+++ b/src/functions/distributed-engines/Get-TssDistributedEngineSite.ps1
@@ -59,8 +59,7 @@ function Get-TssDistributedEngineSite {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.DistributedEngines.Site].GetProperties().Name
-                    [Thycotic.PowerShell.DistributedEngines.Site]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.DistributedEngines.Site](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.DistributedEngines.Site]))
                 }
             }
         } else {

--- a/src/functions/distributed-engines/New-TssDistributedEngineSite.ps1
+++ b/src/functions/distributed-engines/New-TssDistributedEngineSite.ps1
@@ -129,11 +129,7 @@ function New-TssDistributedEngineSite {
             }
 
             if ($restResponse) {
-                $restResponse | ForEach-Object {
-                    $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                    $_ | Select-Object -Property $NonEmptyProperties
-                [Thycotic.PowerShell.DistributedEngines.Site]$NonEmptyProperties
-                }
+                [Thycotic.PowerShell.DistributedEngines.Site](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.DistributedEngines.Site]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/distributed-engines/Search-TssDistributedEngine.ps1
+++ b/src/functions/distributed-engines/Search-TssDistributedEngine.ps1
@@ -95,8 +95,7 @@ function Search-TssDistributedEngine {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.DistributedEngines.EngineSummary].GetProperties().Name
-                [Thycotic.PowerShell.DistributedEngines.EngineSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.DistributedEngines.EngineSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.DistributedEngines.EngineSummary]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/distributed-engines/Search-TssDistributedEngine.ps1
+++ b/src/functions/distributed-engines/Search-TssDistributedEngine.ps1
@@ -95,7 +95,8 @@ function Search-TssDistributedEngine {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.DistributedEngines.EngineSummary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.DistributedEngines.EngineSummary].GetProperties().Name
+                [Thycotic.PowerShell.DistributedEngines.EngineSummary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/distributed-engines/Search-TssDistributedEngineConnector.ps1
+++ b/src/functions/distributed-engines/Search-TssDistributedEngineConnector.ps1
@@ -80,7 +80,8 @@ function Search-TssDistributedEngineConnector {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.DistributedEngines.SiteConnectorSummary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.DistributedEngines.SiteConnectorSummary].GetProperties().Name
+                [Thycotic.PowerShell.DistributedEngines.SiteConnectorSummary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/distributed-engines/Search-TssDistributedEngineConnector.ps1
+++ b/src/functions/distributed-engines/Search-TssDistributedEngineConnector.ps1
@@ -80,8 +80,7 @@ function Search-TssDistributedEngineConnector {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.DistributedEngines.SiteConnectorSummary].GetProperties().Name
-                [Thycotic.PowerShell.DistributedEngines.SiteConnectorSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.DistributedEngines.SiteConnectorSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.DistributedEngines.SiteConnectorSummary]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/distributed-engines/Search-TssDistributedEngineSite.ps1
+++ b/src/functions/distributed-engines/Search-TssDistributedEngineSite.ps1
@@ -108,7 +108,8 @@ function Search-TssDistributedEngineSite {
                 Write-Warning 'No Distributed Engine Sites found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.DistributedEngines.SiteSummary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.DistributedEngines.SiteSummary].GetProperties().Name
+                [Thycotic.PowerShell.DistributedEngines.SiteSummary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/distributed-engines/Search-TssDistributedEngineSite.ps1
+++ b/src/functions/distributed-engines/Search-TssDistributedEngineSite.ps1
@@ -108,8 +108,7 @@ function Search-TssDistributedEngineSite {
                 Write-Warning 'No Distributed Engine Sites found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.DistributedEngines.SiteSummary].GetProperties().Name
-                [Thycotic.PowerShell.DistributedEngines.SiteSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.DistributedEngines.SiteSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.DistributedEngines.SiteSummary]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicy.ps1
+++ b/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicy.ps1
@@ -60,7 +60,8 @@ function Get-TssEventPipelinePolicy {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.EventPipelinePolicy.Policy]$restResponse
+                    $typeProps = [Thycotic.PowerShell.EventPipelinePolicy.Policy].GetProperties().Name
+                    [Thycotic.PowerShell.EventPipelinePolicy.Policy]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicy.ps1
+++ b/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicy.ps1
@@ -60,8 +60,7 @@ function Get-TssEventPipelinePolicy {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.EventPipelinePolicy.Policy].GetProperties().Name
-                    [Thycotic.PowerShell.EventPipelinePolicy.Policy]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.EventPipelinePolicy.Policy](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.EventPipelinePolicy.Policy]))
                 }
             }
         } else {

--- a/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicyActivity.ps1
+++ b/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicyActivity.ps1
@@ -72,7 +72,8 @@ function Get-TssEventPipelinePolicyActivity {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.EventPipelinePolicy.Activity[]]$restResponse
+                $typeProps = [Thycotic.PowerShell.EventPipelinePolicy.Activity].GetProperties().Name
+                [Thycotic.PowerShell.EventPipelinePolicy.Activity[]]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicyActivity.ps1
+++ b/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicyActivity.ps1
@@ -72,8 +72,7 @@ function Get-TssEventPipelinePolicyActivity {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.EventPipelinePolicy.Activity].GetProperties().Name
-                [Thycotic.PowerShell.EventPipelinePolicy.Activity[]]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.EventPipelinePolicy.Activity[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.EventPipelinePolicy.Activity]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/event-pipeline-policy/Search-TssEventPipelinePolicy.ps1
+++ b/src/functions/event-pipeline-policy/Search-TssEventPipelinePolicy.ps1
@@ -100,7 +100,8 @@ function Search-TssEventPipelinePolicy {
             }
 
             if ($restResponse.records) {
-                [Thycotic.PowerShell.EventPipelinePolicy.List[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.EventPipelinePolicy.List].GetProperties().Name
+                [Thycotic.PowerShell.EventPipelinePolicy.List[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/event-pipeline-policy/Search-TssEventPipelinePolicy.ps1
+++ b/src/functions/event-pipeline-policy/Search-TssEventPipelinePolicy.ps1
@@ -100,8 +100,7 @@ function Search-TssEventPipelinePolicy {
             }
 
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.EventPipelinePolicy.List].GetProperties().Name
-                [Thycotic.PowerShell.EventPipelinePolicy.List[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.EventPipelinePolicy.List[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.EventPipelinePolicy.List]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/event-pipeline/Get-TssEventPipelineRun.ps1
+++ b/src/functions/event-pipeline/Get-TssEventPipelineRun.ps1
@@ -65,7 +65,8 @@ function Get-TssEventPipelineRun {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.EventPipeline.RunView[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.EventPipeline.RunView].GetProperties().Name
+                    [Thycotic.PowerShell.EventPipeline.RunView[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/event-pipeline/Get-TssEventPipelineRun.ps1
+++ b/src/functions/event-pipeline/Get-TssEventPipelineRun.ps1
@@ -65,8 +65,7 @@ function Get-TssEventPipelineRun {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.EventPipeline.RunView].GetProperties().Name
-                    [Thycotic.PowerShell.EventPipeline.RunView[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.EventPipeline.RunView[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.EventPipeline.RunView]))
                 }
             }
         } else {

--- a/src/functions/event-pipeline/Search-TssEventPipeline.ps1
+++ b/src/functions/event-pipeline/Search-TssEventPipeline.ps1
@@ -101,8 +101,7 @@ function Search-TssEventPipeline {
             }
 
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.EventPipeline.Summary].GetProperties().Name
-                [Thycotic.PowerShell.EventPipeline.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.EventPipeline.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.EventPipeline.Summary]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/event-pipeline/Search-TssEventPipeline.ps1
+++ b/src/functions/event-pipeline/Search-TssEventPipeline.ps1
@@ -101,7 +101,8 @@ function Search-TssEventPipeline {
             }
 
             if ($restResponse.records) {
-                [Thycotic.PowerShell.EventPipeline.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.EventPipeline.Summary].GetProperties().Name
+                [Thycotic.PowerShell.EventPipeline.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/folder-permissions/Get-TssFolderPermission.ps1
+++ b/src/functions/folder-permissions/Get-TssFolderPermission.ps1
@@ -66,8 +66,7 @@ function Get-TssFolderPermission {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.FolderPermissions.Permission].GetProperties().Name
-                    [Thycotic.PowerShell.FolderPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.FolderPermissions.Permission](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.FolderPermissions.Permission]))
                 }
             }
         } else {

--- a/src/functions/folder-permissions/Get-TssFolderPermission.ps1
+++ b/src/functions/folder-permissions/Get-TssFolderPermission.ps1
@@ -66,7 +66,8 @@ function Get-TssFolderPermission {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.FolderPermissions.Permission]$restResponse
+                    $typeProps = [Thycotic.PowerShell.FolderPermissions.Permission].GetProperties().Name
+                    [Thycotic.PowerShell.FolderPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/folder-permissions/New-TssFolderPermission.ps1
+++ b/src/functions/folder-permissions/New-TssFolderPermission.ps1
@@ -116,8 +116,7 @@ function New-TssFolderPermission {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.FolderPermissions.Permission].GetProperties().Name
-                        [Thycotic.PowerShell.FolderPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.FolderPermissions.Permission](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.FolderPermissions.Permission]))
                     }
                 }
             } else {

--- a/src/functions/folder-permissions/New-TssFolderPermission.ps1
+++ b/src/functions/folder-permissions/New-TssFolderPermission.ps1
@@ -116,7 +116,8 @@ function New-TssFolderPermission {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.FolderPermissions.Permission]$restResponse
+                        $typeProps = [Thycotic.PowerShell.FolderPermissions.Permission].GetProperties().Name
+                        [Thycotic.PowerShell.FolderPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             } else {

--- a/src/functions/folder-permissions/Remove-TssFolderPermission.ps1
+++ b/src/functions/folder-permissions/Remove-TssFolderPermission.ps1
@@ -71,7 +71,8 @@ function Remove-TssFolderPermission {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Common.Delete]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
+                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/folder-permissions/Remove-TssFolderPermission.ps1
+++ b/src/functions/folder-permissions/Remove-TssFolderPermission.ps1
@@ -71,8 +71,7 @@ function Remove-TssFolderPermission {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
-                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Common.Delete](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Common.Delete]))
                     }
                 }
             }

--- a/src/functions/folder-permissions/Search-TssFolderPermission.ps1
+++ b/src/functions/folder-permissions/Search-TssFolderPermission.ps1
@@ -91,7 +91,7 @@ function Search-TssFolderPermission {
                     Write-Warning 'No Folder Permissions found'
                 }
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.FolderPermissions.Permission[]]$restResponse.records
+                    [Thycotic.PowerShell.FolderPermissions.Permission[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.FolderPermissions.Permission]))
                 }
             } else {
                 Write-Error 'Please provide one of the following parameters: -FolderId, -GroupId or -UserId'

--- a/src/functions/folder-permissions/Update-TssFolderPermission.ps1
+++ b/src/functions/folder-permissions/Update-TssFolderPermission.ps1
@@ -101,7 +101,8 @@ function Update-TssFolderPermission {
                     }
                 }
                 if ($restResponse) {
-                    [Thycotic.PowerShell.FolderPermissions.Permission]$restResponse
+                    $typeProps = [Thycotic.PowerShell.FolderPermissions.Permission].GetProperties().Name
+                    [Thycotic.PowerShell.FolderPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/folder-permissions/Update-TssFolderPermission.ps1
+++ b/src/functions/folder-permissions/Update-TssFolderPermission.ps1
@@ -101,8 +101,7 @@ function Update-TssFolderPermission {
                     }
                 }
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.FolderPermissions.Permission].GetProperties().Name
-                    [Thycotic.PowerShell.FolderPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.FolderPermissions.Permission](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.FolderPermissions.Permission]))
                 }
             }
         } else {

--- a/src/functions/folders/Find-TssFolder.ps1
+++ b/src/functions/folders/Find-TssFolder.ps1
@@ -101,8 +101,7 @@ function Find-TssFolder {
                 Write-Warning 'No Folder found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Folders.Lookup].GetProperties().Name
-                [Thycotic.PowerShell.Folders.Lookup[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Folders.Lookup[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Folders.Lookup]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/folders/Find-TssFolder.ps1
+++ b/src/functions/folders/Find-TssFolder.ps1
@@ -101,7 +101,8 @@ function Find-TssFolder {
                 Write-Warning 'No Folder found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Folders.Lookup[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Folders.Lookup].GetProperties().Name
+                [Thycotic.PowerShell.Folders.Lookup[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/folders/Get-TssFolder.ps1
+++ b/src/functions/folders/Get-TssFolder.ps1
@@ -105,11 +105,7 @@ function Get-TssFolder {
                     }
 
                     if ($restResponse) {
-                        $restResponse | ForEach-Object {
-                            $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                            $_ | Select-Object -Property $NonEmptyProperties
-                        }
-                        [Thycotic.PowerShell.Folders.Folder[]]$NonEmptyProperties
+                        [Thycotic.PowerShell.Folders.Folder[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Folders.Folder]))
                     }
                 }
             }
@@ -133,11 +129,7 @@ function Get-TssFolder {
                     }
 
                     if ($restResponse) {
-                        $restResponse | ForEach-Object {
-                            $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                            $_ | Select-Object -Property $NonEmptyProperties
-                        }
-                        [Thycotic.PowerShell.Folders.Folder[]]$NonEmptyProperties
+                        [Thycotic.PowerShell.Folders.Folder[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Folders.Folder]))
                     }
                 }
             }

--- a/src/functions/folders/Get-TssFolderAudit.ps1
+++ b/src/functions/folders/Get-TssFolderAudit.ps1
@@ -62,7 +62,8 @@ function Get-TssFolderAudit {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Folders.AuditSummary[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Folders.AuditSummary].GetProperties().Name
+                    [Thycotic.PowerShell.Folders.AuditSummary[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/folders/Get-TssFolderAudit.ps1
+++ b/src/functions/folders/Get-TssFolderAudit.ps1
@@ -62,8 +62,7 @@ function Get-TssFolderAudit {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.Folders.AuditSummary].GetProperties().Name
-                    [Thycotic.PowerShell.Folders.AuditSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Folders.AuditSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Folders.AuditSummary]))
                 }
             }
         } else {

--- a/src/functions/folders/Get-TssFolderState.ps1
+++ b/src/functions/folders/Get-TssFolderState.ps1
@@ -74,8 +74,7 @@ function Get-TssFolderState {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Folders.DetailView].GetProperties().Name
-                    [Thycotic.PowerShell.Folders.DetailView]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Folders.DetailView](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Folders.DetailView]))
                 }
             }
         } else {

--- a/src/functions/folders/Get-TssFolderState.ps1
+++ b/src/functions/folders/Get-TssFolderState.ps1
@@ -74,7 +74,8 @@ function Get-TssFolderState {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Folders.DetailView]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Folders.DetailView].GetProperties().Name
+                    [Thycotic.PowerShell.Folders.DetailView]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/folders/New-TssFolder.ps1
+++ b/src/functions/folders/New-TssFolder.ps1
@@ -125,8 +125,7 @@ function New-TssFolder {
                 . $ErrorHandling $err
             }
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Folders.Folder].GetProperties().Name
-                [Thycotic.PowerShell.Folders.Folder]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Folders.Folder](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Folders.Folder]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/folders/New-TssFolder.ps1
+++ b/src/functions/folders/New-TssFolder.ps1
@@ -125,7 +125,8 @@ function New-TssFolder {
                 . $ErrorHandling $err
             }
             if ($restResponse) {
-                [Thycotic.PowerShell.Folders.Folder]$restResponse
+                $typeProps = [Thycotic.PowerShell.Folders.Folder].GetProperties().Name
+                [Thycotic.PowerShell.Folders.Folder]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/folders/Remove-TssFolder.ps1
+++ b/src/functions/folders/Remove-TssFolder.ps1
@@ -63,7 +63,8 @@ function Remove-TssFolder {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Common.Delete]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
+                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/folders/Remove-TssFolder.ps1
+++ b/src/functions/folders/Remove-TssFolder.ps1
@@ -63,8 +63,7 @@ function Remove-TssFolder {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
-                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Common.Delete](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Common.Delete]))
                     }
                 }
             }

--- a/src/functions/folders/Remove-TssFolderTemplate.ps1
+++ b/src/functions/folders/Remove-TssFolderTemplate.ps1
@@ -67,7 +67,8 @@ function Remove-TssFolderTemplate {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Common.Delete]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
+                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/folders/Remove-TssFolderTemplate.ps1
+++ b/src/functions/folders/Remove-TssFolderTemplate.ps1
@@ -67,8 +67,7 @@ function Remove-TssFolderTemplate {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
-                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Common.Delete](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Common.Delete]))
                     }
                 }
             }

--- a/src/functions/folders/Search-TssFolder.ps1
+++ b/src/functions/folders/Search-TssFolder.ps1
@@ -95,7 +95,8 @@ function Search-TssFolder {
                 Write-Warning 'No Folder found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Folders.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Folders.Summary].GetProperties().Name
+                [Thycotic.PowerShell.Folders.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/folders/Search-TssFolder.ps1
+++ b/src/functions/folders/Search-TssFolder.ps1
@@ -95,8 +95,7 @@ function Search-TssFolder {
                 Write-Warning 'No Folder found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Folders.Summary].GetProperties().Name
-                [Thycotic.PowerShell.Folders.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Folders.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Folders.Summary]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/folders/Update-TssFolder.ps1
+++ b/src/functions/folders/Update-TssFolder.ps1
@@ -63,8 +63,7 @@ function Update-TssFolder {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Folders.Folder].GetProperties().Name
-                    [Thycotic.PowerShell.Folders.Folder]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Folders.Folder](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Folders.Folder]))
                 }
             }
         } else {

--- a/src/functions/folders/Update-TssFolder.ps1
+++ b/src/functions/folders/Update-TssFolder.ps1
@@ -63,7 +63,8 @@ function Update-TssFolder {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Folders.Folder]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Folders.Folder].GetProperties().Name
+                    [Thycotic.PowerShell.Folders.Folder]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/groups/Add-TssGroupMember.ps1
+++ b/src/functions/groups/Add-TssGroupMember.ps1
@@ -68,8 +68,7 @@ function Add-TssGroupMember {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Groups.User].GetProperties().Name
-                        [Thycotic.PowerShell.Groups.User]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Groups.User](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Groups.User]))
                     }
                 }
             }

--- a/src/functions/groups/Add-TssGroupMember.ps1
+++ b/src/functions/groups/Add-TssGroupMember.ps1
@@ -68,7 +68,8 @@ function Add-TssGroupMember {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Groups.User]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Groups.User].GetProperties().Name
+                        [Thycotic.PowerShell.Groups.User]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/groups/Find-TssGroup.ps1
+++ b/src/functions/groups/Find-TssGroup.ps1
@@ -96,8 +96,7 @@ function Find-TssGroup {
                 Write-Warning 'No Group found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Groups.Lookup].GetProperties().Name
-                [Thycotic.PowerShell.Groups.Lookup[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Groups.Lookup[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Groups.Lookup]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/groups/Find-TssGroup.ps1
+++ b/src/functions/groups/Find-TssGroup.ps1
@@ -96,7 +96,8 @@ function Find-TssGroup {
                 Write-Warning 'No Group found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Groups.Lookup[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Groups.Lookup].GetProperties().Name
+                [Thycotic.PowerShell.Groups.Lookup[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/groups/Get-TssGroupMember.ps1
+++ b/src/functions/groups/Get-TssGroupMember.ps1
@@ -87,7 +87,8 @@ function Get-TssGroupMember {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Groups.UserSummary[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Groups.UserSummary].GetProperties().Name
+                    [Thycotic.PowerShell.Groups.UserSummary[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/groups/Get-TssGroupMember.ps1
+++ b/src/functions/groups/Get-TssGroupMember.ps1
@@ -87,8 +87,7 @@ function Get-TssGroupMember {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.Groups.UserSummary].GetProperties().Name
-                    [Thycotic.PowerShell.Groups.UserSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Groups.UserSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Groups.UserSummary]))
                 }
             }
         } else {

--- a/src/functions/groups/Get-TssGroupRole.ps1
+++ b/src/functions/groups/Get-TssGroupRole.ps1
@@ -60,7 +60,8 @@ function Get-TssGroupRole {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Groups.RoleSummary[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Groups.RoleSummary].GetProperties().Name
+                    [Thycotic.PowerShell.Groups.RoleSummary[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/groups/Get-TssGroupRole.ps1
+++ b/src/functions/groups/Get-TssGroupRole.ps1
@@ -60,8 +60,7 @@ function Get-TssGroupRole {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.Groups.RoleSummary].GetProperties().Name
-                    [Thycotic.PowerShell.Groups.RoleSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Groups.RoleSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Groups.RoleSummary]))
                 }
             }
         } else {

--- a/src/functions/groups/Get-TssGroupUser.ps1
+++ b/src/functions/groups/Get-TssGroupUser.ps1
@@ -64,8 +64,7 @@ function Get-TssGroupUser {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Groups.User].GetProperties().Name
-                [Thycotic.PowerShell.Groups.User]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Groups.User](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Groups.User]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/groups/Get-TssGroupUser.ps1
+++ b/src/functions/groups/Get-TssGroupUser.ps1
@@ -64,7 +64,8 @@ function Get-TssGroupUser {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Groups.User]$restResponse
+                $typeProps = [Thycotic.PowerShell.Groups.User].GetProperties().Name
+                [Thycotic.PowerShell.Groups.User]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/groups/Search-TssGroup.ps1
+++ b/src/functions/groups/Search-TssGroup.ps1
@@ -90,7 +90,8 @@ function Search-TssGroup {
                 Write-Warning 'No groups found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Groups.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Groups.Summary].GetProperties().Name
+                [Thycotic.PowerShell.Groups.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/groups/Search-TssGroup.ps1
+++ b/src/functions/groups/Search-TssGroup.ps1
@@ -90,8 +90,7 @@ function Search-TssGroup {
                 Write-Warning 'No groups found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Groups.Summary].GetProperties().Name
-                [Thycotic.PowerShell.Groups.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Groups.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Groups.Summary]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/ipaddress-restrictions/New-TssIpRestriction.ps1
+++ b/src/functions/ipaddress-restrictions/New-TssIpRestriction.ps1
@@ -77,8 +77,7 @@ function New-TssIpRestriction {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.IpRestrictions.IpRestriction].GetProperties().Name
-                [Thycotic.PowerShell.IpRestrictions.IpRestriction]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.IpRestrictions.IpRestriction](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.IpRestrictions.IpRestriction]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/ipaddress-restrictions/New-TssIpRestriction.ps1
+++ b/src/functions/ipaddress-restrictions/New-TssIpRestriction.ps1
@@ -77,7 +77,8 @@ function New-TssIpRestriction {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.IpRestrictions.IpRestriction]$restResponse
+                $typeProps = [Thycotic.PowerShell.IpRestrictions.IpRestriction].GetProperties().Name
+                [Thycotic.PowerShell.IpRestrictions.IpRestriction]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/ipaddress-restrictions/Search-TssIpRestriction.ps1
+++ b/src/functions/ipaddress-restrictions/Search-TssIpRestriction.ps1
@@ -61,7 +61,8 @@ function Search-TssIpRestriction {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.IpRestrictions.IpRestriction[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.IpRestrictions.IpRestriction].GetProperties().Name
+                [Thycotic.PowerShell.IpRestrictions.IpRestriction[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/ipaddress-restrictions/Search-TssIpRestriction.ps1
+++ b/src/functions/ipaddress-restrictions/Search-TssIpRestriction.ps1
@@ -61,8 +61,7 @@ function Search-TssIpRestriction {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.IpRestrictions.IpRestriction].GetProperties().Name
-                [Thycotic.PowerShell.IpRestrictions.IpRestriction[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.IpRestrictions.IpRestriction[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.IpRestrictions.IpRestriction]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/ipaddress-restrictions/Search-TssIpRestrictionGroup.ps1
+++ b/src/functions/ipaddress-restrictions/Search-TssIpRestrictionGroup.ps1
@@ -79,8 +79,7 @@ function Search-TssIpRestrictionGroup {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.IpRestrictions.Group].GetProperties().Name
-                [Thycotic.PowerShell.IpRestrictions.Group[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.IpRestrictions.Group[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.IpRestrictions.Group]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/ipaddress-restrictions/Search-TssIpRestrictionGroup.ps1
+++ b/src/functions/ipaddress-restrictions/Search-TssIpRestrictionGroup.ps1
@@ -79,7 +79,8 @@ function Search-TssIpRestrictionGroup {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.IpRestrictions.Group[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.IpRestrictions.Group].GetProperties().Name
+                [Thycotic.PowerShell.IpRestrictions.Group[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/ipaddress-restrictions/Search-TssIpRestrictionUser.ps1
+++ b/src/functions/ipaddress-restrictions/Search-TssIpRestrictionUser.ps1
@@ -79,7 +79,8 @@ function Search-TssIpRestrictionUser {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.IpRestrictions.User[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.IpRestrictions.User].GetProperties().Name
+                [Thycotic.PowerShell.IpRestrictions.User[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/ipaddress-restrictions/Search-TssIpRestrictionUser.ps1
+++ b/src/functions/ipaddress-restrictions/Search-TssIpRestrictionUser.ps1
@@ -79,8 +79,7 @@ function Search-TssIpRestrictionUser {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.IpRestrictions.User].GetProperties().Name
-                [Thycotic.PowerShell.IpRestrictions.User[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.IpRestrictions.User[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.IpRestrictions.User]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/ipaddress-restrictions/Update-TssIpRestriction.ps1
+++ b/src/functions/ipaddress-restrictions/Update-TssIpRestriction.ps1
@@ -68,7 +68,8 @@ function Update-TssIpRestriction {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.IpRestrictions.IpRestriction]$restResponse
+                    $typeProps = [Thycotic.PowerShell.IpRestrictions.IpRestriction].GetProperties().Name
+                    [Thycotic.PowerShell.IpRestrictions.IpRestriction]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/ipaddress-restrictions/Update-TssIpRestriction.ps1
+++ b/src/functions/ipaddress-restrictions/Update-TssIpRestriction.ps1
@@ -68,8 +68,7 @@ function Update-TssIpRestriction {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.IpRestrictions.IpRestriction].GetProperties().Name
-                    [Thycotic.PowerShell.IpRestrictions.IpRestriction]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.IpRestrictions.IpRestriction](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.IpRestrictions.IpRestriction]))
                 }
             }
         } else {

--- a/src/functions/lists/Clear-TssList.ps1
+++ b/src/functions/lists/Clear-TssList.ps1
@@ -66,7 +66,8 @@ function Clear-TssList {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Common.Delete]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
+                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/lists/Clear-TssList.ps1
+++ b/src/functions/lists/Clear-TssList.ps1
@@ -66,8 +66,7 @@ function Clear-TssList {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
-                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Common.Delete](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Common.Delete]))
                     }
                 }
             }

--- a/src/functions/lists/Get-TssList.ps1
+++ b/src/functions/lists/Get-TssList.ps1
@@ -59,8 +59,7 @@ function Get-TssList {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Lists.List].GetProperties().Name
-                    [Thycotic.PowerShell.Lists.List[]]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Lists.List[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Lists.List]))
                 }
             }
         } else {

--- a/src/functions/lists/Get-TssList.ps1
+++ b/src/functions/lists/Get-TssList.ps1
@@ -59,7 +59,8 @@ function Get-TssList {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Lists.List[]]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Lists.List].GetProperties().Name
+                    [Thycotic.PowerShell.Lists.List[]]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/lists/Get-TssListOption.ps1
+++ b/src/functions/lists/Get-TssListOption.ps1
@@ -85,7 +85,8 @@ function Get-TssListOption {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Lists.Item[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Lists.Item].GetProperties().Name
+                    [Thycotic.PowerShell.Lists.Item[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/lists/Get-TssListOption.ps1
+++ b/src/functions/lists/Get-TssListOption.ps1
@@ -85,8 +85,7 @@ function Get-TssListOption {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.Lists.Item].GetProperties().Name
-                    [Thycotic.PowerShell.Lists.Item[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Lists.Item[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Lists.Item]))
                 }
             }
         } else {

--- a/src/functions/lists/New-TssList.ps1
+++ b/src/functions/lists/New-TssList.ps1
@@ -99,8 +99,7 @@ function New-TssList {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Lists.List].GetProperties().Name
-                [Thycotic.PowerShell.Lists.List]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Lists.List](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Lists.List]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/lists/New-TssList.ps1
+++ b/src/functions/lists/New-TssList.ps1
@@ -99,7 +99,8 @@ function New-TssList {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Lists.List]$restResponse
+                $typeProps = [Thycotic.PowerShell.Lists.List].GetProperties().Name
+                [Thycotic.PowerShell.Lists.List]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/lists/Remove-TssList.ps1
+++ b/src/functions/lists/Remove-TssList.ps1
@@ -60,8 +60,7 @@ function Remove-TssList {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
-                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Common.Delete](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Common.Delete]))
                     }
                 }
             }

--- a/src/functions/lists/Remove-TssList.ps1
+++ b/src/functions/lists/Remove-TssList.ps1
@@ -60,7 +60,8 @@ function Remove-TssList {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Common.Delete]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
+                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/lists/Search-TssList.ps1
+++ b/src/functions/lists/Search-TssList.ps1
@@ -80,7 +80,8 @@ function Search-TssList {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Lists.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Lists.Summary].GetProperties().Name
+                [Thycotic.PowerShell.Lists.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/lists/Search-TssList.ps1
+++ b/src/functions/lists/Search-TssList.ps1
@@ -80,8 +80,7 @@ function Search-TssList {
                 Write-Warning "No records found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Lists.Summary].GetProperties().Name
-                [Thycotic.PowerShell.Lists.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Lists.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Lists.Summary]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/lists/Show-TssListCurrentUser.ps1
+++ b/src/functions/lists/Show-TssListCurrentUser.ps1
@@ -52,7 +52,8 @@ function Show-TssListCurrentUser {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Lists.SummaryList[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Lists.SummaryList].GetProperties().Name
+                    [Thycotic.PowerShell.Lists.SummaryList[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             } else {
                 Write-Warning "No valid session found"

--- a/src/functions/lists/Show-TssListCurrentUser.ps1
+++ b/src/functions/lists/Show-TssListCurrentUser.ps1
@@ -52,8 +52,7 @@ function Show-TssListCurrentUser {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.Lists.SummaryList].GetProperties().Name
-                    [Thycotic.PowerShell.Lists.SummaryList[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Lists.SummaryList[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Lists.SummaryList]))
                 }
             } else {
                 Write-Warning "No valid session found"

--- a/src/functions/lists/Update-TssList.ps1
+++ b/src/functions/lists/Update-TssList.ps1
@@ -95,8 +95,7 @@ function Update-TssList {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Lists.List].GetProperties().Name
-                        [Thycotic.PowerShell.Lists.List[]]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Lists.List[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Lists.List]))
                     }
                 }
             }

--- a/src/functions/lists/Update-TssList.ps1
+++ b/src/functions/lists/Update-TssList.ps1
@@ -95,7 +95,8 @@ function Update-TssList {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Lists.List[]]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Lists.List].GetProperties().Name
+                        [Thycotic.PowerShell.Lists.List[]]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/metadata/Get-TssMetadataField.ps1
+++ b/src/functions/metadata/Get-TssMetadataField.ps1
@@ -52,7 +52,8 @@ function Get-TssMetadataField {
             }
 
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Metadata.FieldSummary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Metadata.FieldSummary].GetProperties().Name
+                [Thycotic.PowerShell.Metadata.FieldSummary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/Get-TssMetadataField.ps1
+++ b/src/functions/metadata/Get-TssMetadataField.ps1
@@ -52,8 +52,7 @@ function Get-TssMetadataField {
             }
 
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Metadata.FieldSummary].GetProperties().Name
-                [Thycotic.PowerShell.Metadata.FieldSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Metadata.FieldSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Metadata.FieldSummary]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/New-TssMetadataField.ps1
+++ b/src/functions/metadata/New-TssMetadataField.ps1
@@ -157,11 +157,7 @@ function New-TssMetadataField {
             }
 
             if ($restResponse) {
-                $restResponse | ForEach-Object {
-                    $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                    $_ | Select-Object -Property $NonEmptyProperties
-                }
-                [Thycotic.PowerShell.Metadata.Field]$NonEmptyProperties
+                [Thycotic.PowerShell.Metadata.Field](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Metadata.Field]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/Search-TssMetadata.ps1
+++ b/src/functions/metadata/Search-TssMetadata.ps1
@@ -91,8 +91,7 @@ function Search-TssMetadata {
                 Write-Warning "No Metadata found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Metadata.Summary].GetProperties().Name
-                [Thycotic.PowerShell.Metadata.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Metadata.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Metadata.Summary]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/Search-TssMetadata.ps1
+++ b/src/functions/metadata/Search-TssMetadata.ps1
@@ -91,7 +91,8 @@ function Search-TssMetadata {
                 Write-Warning "No Metadata found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Metadata.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Metadata.Summary].GetProperties().Name
+                [Thycotic.PowerShell.Metadata.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/Search-TssMetadataHistory.ps1
+++ b/src/functions/metadata/Search-TssMetadataHistory.ps1
@@ -98,8 +98,7 @@ function Search-TssMetadataHistory {
                 Write-Warning "No MetadataHistory found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Metadata.History].GetProperties().Name
-                [Thycotic.PowerShell.Metadata.History[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Metadata.History[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Metadata.History]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/Search-TssMetadataHistory.ps1
+++ b/src/functions/metadata/Search-TssMetadataHistory.ps1
@@ -98,7 +98,8 @@ function Search-TssMetadataHistory {
                 Write-Warning "No MetadataHistory found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Metadata.History[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Metadata.History].GetProperties().Name
+                [Thycotic.PowerShell.Metadata.History[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/Search-TssMetadataSection.ps1
+++ b/src/functions/metadata/Search-TssMetadataSection.ps1
@@ -89,7 +89,8 @@ function Search-TssMetadataSection {
                 Write-Warning "No MetadataSection found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Metadata.FieldSectionSummary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Metadata.FieldSectionSummary].GetProperties().Name
+                [Thycotic.PowerShell.Metadata.FieldSectionSummary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/Search-TssMetadataSection.ps1
+++ b/src/functions/metadata/Search-TssMetadataSection.ps1
@@ -89,8 +89,7 @@ function Search-TssMetadataSection {
                 Write-Warning "No MetadataSection found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Metadata.FieldSectionSummary].GetProperties().Name
-                [Thycotic.PowerShell.Metadata.FieldSectionSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Metadata.FieldSectionSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Metadata.FieldSectionSummary]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/metadata/Update-TssMetadataField.ps1
+++ b/src/functions/metadata/Update-TssMetadataField.ps1
@@ -133,11 +133,7 @@ function Update-TssMetadataField {
                 }
 
                 if ($restResponse) {
-                    $restResponse | ForEach-Object {
-                        $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                        $_ | Select-Object -Property $NonEmptyProperties
-                    }
-                    [Thycotic.PowerShell.Metadata.Field]$NonEmptyProperties
+                    [Thycotic.PowerShell.Metadata.Field](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Metadata.Field]))
                 }
             }
         } else {

--- a/src/functions/metadata/Update-TssMetadataSection.ps1
+++ b/src/functions/metadata/Update-TssMetadataSection.ps1
@@ -131,7 +131,8 @@ function Update-TssMetadataSection {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Metadata.FieldSectionSummary]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Metadata.FieldSectionSummary].GetProperties().Name
+                    [Thycotic.PowerShell.Metadata.FieldSectionSummary]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/metadata/Update-TssMetadataSection.ps1
+++ b/src/functions/metadata/Update-TssMetadataSection.ps1
@@ -131,8 +131,7 @@ function Update-TssMetadataSection {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Metadata.FieldSectionSummary].GetProperties().Name
-                    [Thycotic.PowerShell.Metadata.FieldSectionSummary]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Metadata.FieldSectionSummary](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Metadata.FieldSectionSummary]))
                 }
             }
         } else {

--- a/src/functions/remote-password-changing/Get-TssRpcPasswordType.ps1
+++ b/src/functions/remote-password-changing/Get-TssRpcPasswordType.ps1
@@ -60,8 +60,7 @@ function Get-TssRpcPasswordType {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Rpc.PasswordType].GetProperties().Name
-                    [Thycotic.PowerShell.Rpc.PasswordType]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Rpc.PasswordType](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Rpc.PasswordType]))
                 }
             }
         } else {

--- a/src/functions/remote-password-changing/Get-TssRpcPasswordType.ps1
+++ b/src/functions/remote-password-changing/Get-TssRpcPasswordType.ps1
@@ -60,7 +60,8 @@ function Get-TssRpcPasswordType {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Rpc.PasswordType]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Rpc.PasswordType].GetProperties().Name
+                    [Thycotic.PowerShell.Rpc.PasswordType]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/remote-password-changing/Search-TssRpcPasswordType.ps1
+++ b/src/functions/remote-password-changing/Search-TssRpcPasswordType.ps1
@@ -83,7 +83,8 @@ function Search-TssRpcPasswordType {
                 Write-Warning 'No RpcPasswordType found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Rpc.PasswordTypeSummary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Rpc.PasswordTypeSummary].GetProperties().Name
+                [Thycotic.PowerShell.Rpc.PasswordTypeSummary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/remote-password-changing/Search-TssRpcPasswordType.ps1
+++ b/src/functions/remote-password-changing/Search-TssRpcPasswordType.ps1
@@ -83,8 +83,7 @@ function Search-TssRpcPasswordType {
                 Write-Warning 'No RpcPasswordType found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Rpc.PasswordTypeSummary].GetProperties().Name
-                [Thycotic.PowerShell.Rpc.PasswordTypeSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Rpc.PasswordTypeSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Rpc.PasswordTypeSummary]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/reports/Find-TssReport.ps1
+++ b/src/functions/reports/Find-TssReport.ps1
@@ -95,7 +95,8 @@ function Find-TssReport {
             }
 
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Reports.Lookup[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Reports.Lookup].GetProperties().Name
+                [Thycotic.PowerShell.Reports.Lookup[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/reports/Find-TssReport.ps1
+++ b/src/functions/reports/Find-TssReport.ps1
@@ -95,8 +95,7 @@ function Find-TssReport {
             }
 
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Reports.Lookup].GetProperties().Name
-                [Thycotic.PowerShell.Reports.Lookup[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Reports.Lookup[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Reports.Lookup]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/reports/Get-TssReport.ps1
+++ b/src/functions/reports/Get-TssReport.ps1
@@ -61,8 +61,7 @@ function Get-TssReport {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Reports.Report].GetProperties().Name
-                    [Thycotic.PowerShell.Reports.Report]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Reports.Report](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Reports.Report]))
                 }
             }
         } else {

--- a/src/functions/reports/Get-TssReport.ps1
+++ b/src/functions/reports/Get-TssReport.ps1
@@ -61,7 +61,8 @@ function Get-TssReport {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Reports.Report]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Reports.Report].GetProperties().Name
+                    [Thycotic.PowerShell.Reports.Report]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/reports/Get-TssReportCategory.ps1
+++ b/src/functions/reports/Get-TssReportCategory.ps1
@@ -93,7 +93,8 @@ function Get-TssReportCategory {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Reports.Category[]]$restResponse.model
+                    $typeProps = [Thycotic.PowerShell.Reports.Category].GetProperties().Name
+                    [Thycotic.PowerShell.Reports.Category[]]($restResponse.model | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/reports/Get-TssReportCategory.ps1
+++ b/src/functions/reports/Get-TssReportCategory.ps1
@@ -93,8 +93,7 @@ function Get-TssReportCategory {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Reports.Category].GetProperties().Name
-                    [Thycotic.PowerShell.Reports.Category[]]($restResponse.model | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Reports.Category[]](. $FilterTssResponse $restResponse.model ([Thycotic.PowerShell.Reports.Category]))
                 }
             }
         } else {

--- a/src/functions/reports/Get-TssReportParameter.ps1
+++ b/src/functions/reports/Get-TssReportParameter.ps1
@@ -59,7 +59,8 @@ function Get-TssReportParameter {
             }
 
             if ($restResponse.defaultParameterValues) {
-                [Thycotic.PowerShell.Reports.Parameter[]]$restResponse.defaultParameterValues
+                $typeProps = [Thycotic.PowerShell.Reports.Parameter].GetProperties().Name
+                [Thycotic.PowerShell.Reports.Parameter[]]($restResponse.defaultParameterValues | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/reports/Get-TssReportParameter.ps1
+++ b/src/functions/reports/Get-TssReportParameter.ps1
@@ -59,8 +59,7 @@ function Get-TssReportParameter {
             }
 
             if ($restResponse.defaultParameterValues) {
-                $typeProps = [Thycotic.PowerShell.Reports.Parameter].GetProperties().Name
-                [Thycotic.PowerShell.Reports.Parameter[]]($restResponse.defaultParameterValues | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Reports.Parameter[]](. $FilterTssResponse $restResponse.defaultParameterValues ([Thycotic.PowerShell.Reports.Parameter]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/reports/New-TssReport.ps1
+++ b/src/functions/reports/New-TssReport.ps1
@@ -125,7 +125,8 @@ function New-TssReport {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Reports.Report]$restResponse
+                $typeProps = [Thycotic.PowerShell.Reports.Report].GetProperties().Name
+                [Thycotic.PowerShell.Reports.Report]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/reports/New-TssReport.ps1
+++ b/src/functions/reports/New-TssReport.ps1
@@ -125,8 +125,7 @@ function New-TssReport {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Reports.Report].GetProperties().Name
-                [Thycotic.PowerShell.Reports.Report]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Reports.Report](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Reports.Report]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/reports/Remove-TssReportCategory.ps1
+++ b/src/functions/reports/Remove-TssReportCategory.ps1
@@ -70,8 +70,7 @@ function Remove-TssReportCategory {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
-                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Common.Delete](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Common.Delete]))
                     }
                 }
             }

--- a/src/functions/reports/Remove-TssReportCategory.ps1
+++ b/src/functions/reports/Remove-TssReportCategory.ps1
@@ -70,7 +70,8 @@ function Remove-TssReportCategory {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Common.Delete]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
+                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/reports/Search-TssReport.ps1
+++ b/src/functions/reports/Search-TssReport.ps1
@@ -98,7 +98,8 @@ function Search-TssReport {
             }
 
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Reports.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Reports.Summary].GetProperties().Name
+                [Thycotic.PowerShell.Reports.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/reports/Search-TssReport.ps1
+++ b/src/functions/reports/Search-TssReport.ps1
@@ -98,8 +98,7 @@ function Search-TssReport {
             }
 
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Reports.Summary].GetProperties().Name
-                [Thycotic.PowerShell.Reports.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Reports.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Reports.Summary]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/reports/Search-TssReportSchedule.ps1
+++ b/src/functions/reports/Search-TssReportSchedule.ps1
@@ -89,7 +89,8 @@ function Search-TssReportSchedule {
                 Write-Warning 'No report schedules found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Reports.ScheduleSummary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Reports.ScheduleSummary].GetProperties().Name
+                [Thycotic.PowerShell.Reports.ScheduleSummary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/reports/Search-TssReportSchedule.ps1
+++ b/src/functions/reports/Search-TssReportSchedule.ps1
@@ -89,8 +89,7 @@ function Search-TssReportSchedule {
                 Write-Warning 'No report schedules found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Reports.ScheduleSummary].GetProperties().Name
-                [Thycotic.PowerShell.Reports.ScheduleSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Reports.ScheduleSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Reports.ScheduleSummary]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/roles/Search-TssRole.ps1
+++ b/src/functions/roles/Search-TssRole.ps1
@@ -98,8 +98,7 @@ function Search-TssRole {
                 Write-Warning 'No Roles found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Roles.Role].GetProperties().Name
-                [Thycotic.PowerShell.Roles.Role[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Roles.Role[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Roles.Role]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/roles/Search-TssRole.ps1
+++ b/src/functions/roles/Search-TssRole.ps1
@@ -98,7 +98,8 @@ function Search-TssRole {
                 Write-Warning 'No Roles found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Roles.Role[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Roles.Role].GetProperties().Name
+                [Thycotic.PowerShell.Roles.Role[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/scripts/Search-TssScript.ps1
+++ b/src/functions/scripts/Search-TssScript.ps1
@@ -79,8 +79,7 @@ function Search-TssScript {
                 Write-Warning "No Script found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Scripts.Summary].GetProperties().Name
-                [Thycotic.PowerShell.Scripts.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Scripts.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Scripts.Summary]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/scripts/Search-TssScript.ps1
+++ b/src/functions/scripts/Search-TssScript.ps1
@@ -79,7 +79,8 @@ function Search-TssScript {
                 Write-Warning "No Script found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Scripts.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Scripts.Summary].GetProperties().Name
+                [Thycotic.PowerShell.Scripts.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-access-requests/Get-TssSecretAccessRequest.ps1
+++ b/src/functions/secret-access-requests/Get-TssSecretAccessRequest.ps1
@@ -60,7 +60,8 @@ function Get-TssSecretAccessRequest {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.AccessRequests.Request]$restResponse
+                    $typeProps = [Thycotic.PowerShell.AccessRequests.Request].GetProperties().Name
+                    [Thycotic.PowerShell.AccessRequests.Request]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-access-requests/Get-TssSecretAccessRequest.ps1
+++ b/src/functions/secret-access-requests/Get-TssSecretAccessRequest.ps1
@@ -60,8 +60,7 @@ function Get-TssSecretAccessRequest {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.AccessRequests.Request].GetProperties().Name
-                    [Thycotic.PowerShell.AccessRequests.Request]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.AccessRequests.Request](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.AccessRequests.Request]))
                 }
             }
         } else {

--- a/src/functions/secret-access-requests/Get-TssSecretAccessRequestOption.ps1
+++ b/src/functions/secret-access-requests/Get-TssSecretAccessRequestOption.ps1
@@ -60,7 +60,8 @@ function Get-TssSecretAccessRequestOption {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.AccessRequests.Option]$restResponse
+                    $typeProps = [Thycotic.PowerShell.AccessRequests.Option].GetProperties().Name
+                    [Thycotic.PowerShell.AccessRequests.Option]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-access-requests/Get-TssSecretAccessRequestOption.ps1
+++ b/src/functions/secret-access-requests/Get-TssSecretAccessRequestOption.ps1
@@ -60,8 +60,7 @@ function Get-TssSecretAccessRequestOption {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.AccessRequests.Option].GetProperties().Name
-                    [Thycotic.PowerShell.AccessRequests.Option]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.AccessRequests.Option](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.AccessRequests.Option]))
                 }
             }
         } else {

--- a/src/functions/secret-access-requests/Get-TssSecretAccessRequestSecret.ps1
+++ b/src/functions/secret-access-requests/Get-TssSecretAccessRequestSecret.ps1
@@ -60,8 +60,7 @@ function Get-TssSecretAccessRequestSecret {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.AccessRequests.Request].GetProperties().Name
-                    [Thycotic.PowerShell.AccessRequests.Request[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.AccessRequests.Request[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.AccessRequests.Request]))
                 }
             }
         } else {

--- a/src/functions/secret-access-requests/Get-TssSecretAccessRequestSecret.ps1
+++ b/src/functions/secret-access-requests/Get-TssSecretAccessRequestSecret.ps1
@@ -60,7 +60,8 @@ function Get-TssSecretAccessRequestSecret {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.AccessRequests.Request[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.AccessRequests.Request].GetProperties().Name
+                    [Thycotic.PowerShell.AccessRequests.Request[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-access-requests/Search-TssSecretAccessRequest.ps1
+++ b/src/functions/secret-access-requests/Search-TssSecretAccessRequest.ps1
@@ -86,8 +86,7 @@ function Search-TssSecretAccessRequest {
                 Write-Warning "No AccessRequest found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.AccessRequests.Request].GetProperties().Name
-                [Thycotic.PowerShell.AccessRequests.Request[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.AccessRequests.Request[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.AccessRequests.Request]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-access-requests/Search-TssSecretAccessRequest.ps1
+++ b/src/functions/secret-access-requests/Search-TssSecretAccessRequest.ps1
@@ -86,7 +86,8 @@ function Search-TssSecretAccessRequest {
                 Write-Warning "No AccessRequest found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.AccessRequests.Request[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.AccessRequests.Request].GetProperties().Name
+                [Thycotic.PowerShell.AccessRequests.Request[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-dependencies/Get-TssSecretDependency.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependency.ps1
@@ -61,7 +61,8 @@ function Get-TssSecretDependency {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.SecretDependencies.Dependency]$restResponse
+                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Dependency].GetProperties().Name
+                    [Thycotic.PowerShell.SecretDependencies.Dependency]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-dependencies/Get-TssSecretDependency.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependency.ps1
@@ -61,8 +61,7 @@ function Get-TssSecretDependency {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Dependency].GetProperties().Name
-                    [Thycotic.PowerShell.SecretDependencies.Dependency]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretDependencies.Dependency](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretDependencies.Dependency]))
                 }
             }
         } else {

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyGroup.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyGroup.ps1
@@ -61,8 +61,7 @@ function Get-TssSecretDependencyGroup {
                 }
 
                 if ($restResponse.model) {
-                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Group].GetProperties().Name
-                    [Thycotic.PowerShell.SecretDependencies.Group[]]($restResponse.model | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretDependencies.Group[]](. $FilterTssResponse $restResponse.model ([Thycotic.PowerShell.SecretDependencies.Group]))
                 }
             }
         } else {

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyGroup.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyGroup.ps1
@@ -61,7 +61,8 @@ function Get-TssSecretDependencyGroup {
                 }
 
                 if ($restResponse.model) {
-                    [Thycotic.PowerShell.SecretDependencies.Group[]]$restResponse.model
+                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Group].GetProperties().Name
+                    [Thycotic.PowerShell.SecretDependencies.Group[]]($restResponse.model | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyRunStatus.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyRunStatus.ps1
@@ -61,7 +61,8 @@ function Get-TssSecretDependencyRunStatus {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.SecretDependencies.TaskProgress]$restResponse
+                    $typeProps = [Thycotic.PowerShell.SecretDependencies.TaskProgress].GetProperties().Name
+                    [Thycotic.PowerShell.SecretDependencies.TaskProgress]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyRunStatus.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyRunStatus.ps1
@@ -61,8 +61,7 @@ function Get-TssSecretDependencyRunStatus {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.SecretDependencies.TaskProgress].GetProperties().Name
-                    [Thycotic.PowerShell.SecretDependencies.TaskProgress]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretDependencies.TaskProgress](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretDependencies.TaskProgress]))
                 }
             }
         } else {

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyScript.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyScript.ps1
@@ -52,7 +52,8 @@ function Get-TssSecretDependencyScript {
                 }
 
                 if ($restResponse.model) {
-                    [Thycotic.PowerShell.SecretDependencies.Script[]]$restResponse.model
+                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Script].GetProperties().Name
+                    [Thycotic.PowerShell.SecretDependencies.Script[]]($restResponse.model | Select-Object -Property $typeProps)
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyScript.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyScript.ps1
@@ -52,8 +52,7 @@ function Get-TssSecretDependencyScript {
                 }
 
                 if ($restResponse.model) {
-                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Script].GetProperties().Name
-                    [Thycotic.PowerShell.SecretDependencies.Script[]]($restResponse.model | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretDependencies.Script[]](. $FilterTssResponse $restResponse.model ([Thycotic.PowerShell.SecretDependencies.Script]))
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyStub.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyStub.ps1
@@ -92,7 +92,8 @@ function Get-TssSecretDependencyStub {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.SecretDependencies.Dependency]$restResponse
+                $typeProps = [Thycotic.PowerShell.SecretDependencies.Dependency].GetProperties().Name
+                [Thycotic.PowerShell.SecretDependencies.Dependency]($restResponse | Select-Object -Property $typeProps)
             }
 
         } else {

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyStub.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyStub.ps1
@@ -92,8 +92,7 @@ function Get-TssSecretDependencyStub {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.SecretDependencies.Dependency].GetProperties().Name
-                [Thycotic.PowerShell.SecretDependencies.Dependency]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.SecretDependencies.Dependency](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretDependencies.Dependency]))
             }
 
         } else {

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyTemplate.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyTemplate.ps1
@@ -73,7 +73,8 @@ function Get-TssSecretDependencyTemplate {
             }
 
             if ($restResponse.model) {
-                $depTemplates = [Thycotic.PowerShell.SecretDependencies.Template[]]$restResponse.model
+                $typeProps = [Thycotic.PowerShell.SecretDependencies.Template].GetProperties().Name
+                $depTemplates = [Thycotic.PowerShell.SecretDependencies.Template[]]($restResponse.model | Select-Object -Property $typeProps)
                 if ($tssParams.ContainsKey('Template')) {
                     $depTemplates.Where( { $_.Name -eq $Template })
                 } elseif ($tssParams.ContainsKey('Id')) {

--- a/src/functions/secret-dependencies/Get-TssSecretDependencyTemplate.ps1
+++ b/src/functions/secret-dependencies/Get-TssSecretDependencyTemplate.ps1
@@ -73,8 +73,7 @@ function Get-TssSecretDependencyTemplate {
             }
 
             if ($restResponse.model) {
-                $typeProps = [Thycotic.PowerShell.SecretDependencies.Template].GetProperties().Name
-                $depTemplates = [Thycotic.PowerShell.SecretDependencies.Template[]]($restResponse.model | Select-Object -Property $typeProps)
+                $depTemplates = [Thycotic.PowerShell.SecretDependencies.Template[]](. $FilterTssResponse $restResponse.model ([Thycotic.PowerShell.SecretDependencies.Template]))
                 if ($tssParams.ContainsKey('Template')) {
                     $depTemplates.Where( { $_.Name -eq $Template })
                 } elseif ($tssParams.ContainsKey('Id')) {

--- a/src/functions/secret-dependencies/New-TssSecretDependency.ps1
+++ b/src/functions/secret-dependencies/New-TssSecretDependency.ps1
@@ -61,8 +61,7 @@ function New-TssSecretDependency {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.SecretDependencies.Dependency].GetProperties().Name
-                [Thycotic.PowerShell.SecretDependencies.Dependency]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.SecretDependencies.Dependency](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretDependencies.Dependency]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-dependencies/New-TssSecretDependency.ps1
+++ b/src/functions/secret-dependencies/New-TssSecretDependency.ps1
@@ -61,7 +61,8 @@ function New-TssSecretDependency {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.SecretDependencies.Dependency]$restResponse
+                $typeProps = [Thycotic.PowerShell.SecretDependencies.Dependency].GetProperties().Name
+                [Thycotic.PowerShell.SecretDependencies.Dependency]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-dependencies/New-TssSecretDependencyGroup.ps1
+++ b/src/functions/secret-dependencies/New-TssSecretDependencyGroup.ps1
@@ -83,8 +83,7 @@ function New-TssSecretDependencyGroup {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Group].GetProperties().Name
-                    [Thycotic.PowerShell.SecretDependencies.Group]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretDependencies.Group](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretDependencies.Group]))
                 }
             }
         } else {

--- a/src/functions/secret-dependencies/New-TssSecretDependencyGroup.ps1
+++ b/src/functions/secret-dependencies/New-TssSecretDependencyGroup.ps1
@@ -83,7 +83,8 @@ function New-TssSecretDependencyGroup {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.SecretDependencies.Group]$restResponse
+                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Group].GetProperties().Name
+                    [Thycotic.PowerShell.SecretDependencies.Group]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-dependencies/Search-TssSecretDependency.ps1
+++ b/src/functions/secret-dependencies/Search-TssSecretDependency.ps1
@@ -106,8 +106,7 @@ function Search-TssSecretDependency {
                     Write-Warning "No Secret Dependencies found on Secret [$secret]"
                 }
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Summary].GetProperties().Name
-                    [Thycotic.PowerShell.SecretDependencies.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretDependencies.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.SecretDependencies.Summary]))
                 }
             }
         } else {

--- a/src/functions/secret-dependencies/Search-TssSecretDependency.ps1
+++ b/src/functions/secret-dependencies/Search-TssSecretDependency.ps1
@@ -106,7 +106,8 @@ function Search-TssSecretDependency {
                     Write-Warning "No Secret Dependencies found on Secret [$secret]"
                 }
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.SecretDependencies.Summary[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.SecretDependencies.Summary].GetProperties().Name
+                    [Thycotic.PowerShell.SecretDependencies.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-extensions/Get-TssSecretWebTemplate.ps1
+++ b/src/functions/secret-extensions/Get-TssSecretWebTemplate.ps1
@@ -52,7 +52,8 @@ function Get-TssSecretWebTemplate {
             }
 
             if ($restResponse.records) {
-                [Thycotic.PowerShell.SecretTemplates.Template[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.SecretTemplates.Template].GetProperties().Name
+                [Thycotic.PowerShell.SecretTemplates.Template[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-extensions/Get-TssSecretWebTemplate.ps1
+++ b/src/functions/secret-extensions/Get-TssSecretWebTemplate.ps1
@@ -52,8 +52,7 @@ function Get-TssSecretWebTemplate {
             }
 
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.SecretTemplates.Template].GetProperties().Name
-                [Thycotic.PowerShell.SecretTemplates.Template[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.SecretTemplates.Template[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.SecretTemplates.Template]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-extensions/Search-TssSecretsByUrl.ps1
+++ b/src/functions/secret-extensions/Search-TssSecretsByUrl.ps1
@@ -60,7 +60,8 @@ function Search-TssSecretsByUrl {
                 Write-Warning "No records found"
             }
             if ($restResponse.model) {
-                [Thycotic.PowerShell.SecretExtensions.Secret[]]$restResponse.model
+                $typeProps = [Thycotic.PowerShell.SecretExtensions.Secret].GetProperties().Name
+                [Thycotic.PowerShell.SecretExtensions.Secret[]]($restResponse.model | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-extensions/Search-TssSecretsByUrl.ps1
+++ b/src/functions/secret-extensions/Search-TssSecretsByUrl.ps1
@@ -60,8 +60,7 @@ function Search-TssSecretsByUrl {
                 Write-Warning "No records found"
             }
             if ($restResponse.model) {
-                $typeProps = [Thycotic.PowerShell.SecretExtensions.Secret].GetProperties().Name
-                [Thycotic.PowerShell.SecretExtensions.Secret[]]($restResponse.model | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.SecretExtensions.Secret[]](. $FilterTssResponse $restResponse.model ([Thycotic.PowerShell.SecretExtensions.Secret]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-hooks/Search-TssSecretHook.ps1
+++ b/src/functions/secret-hooks/Search-TssSecretHook.ps1
@@ -60,8 +60,7 @@ function Search-TssSecretHook {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.SecretHooks.Summary].GetProperties().Name
-                    [Thycotic.PowerShell.SecretHooks.Summary[]]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretHooks.Summary[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretHooks.Summary]))
                 }
             }
         } else {

--- a/src/functions/secret-hooks/Search-TssSecretHook.ps1
+++ b/src/functions/secret-hooks/Search-TssSecretHook.ps1
@@ -60,7 +60,8 @@ function Search-TssSecretHook {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.SecretHooks.Summary[]]$restResponse
+                    $typeProps = [Thycotic.PowerShell.SecretHooks.Summary].GetProperties().Name
+                    [Thycotic.PowerShell.SecretHooks.Summary[]]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-hooks/Update-TssSecretHook.ps1
+++ b/src/functions/secret-hooks/Update-TssSecretHook.ps1
@@ -284,7 +284,8 @@ function Update-TssSecretHook {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.SecretHooks.Hook]$restResponse
+                    $typeProps = [Thycotic.PowerShell.SecretHooks.Hook].GetProperties().Name
+                    [Thycotic.PowerShell.SecretHooks.Hook]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-hooks/Update-TssSecretHook.ps1
+++ b/src/functions/secret-hooks/Update-TssSecretHook.ps1
@@ -284,8 +284,7 @@ function Update-TssSecretHook {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.SecretHooks.Hook].GetProperties().Name
-                    [Thycotic.PowerShell.SecretHooks.Hook]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretHooks.Hook](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretHooks.Hook]))
                 }
             }
         } else {

--- a/src/functions/secret-permissions/New-TssSecretPermission.ps1
+++ b/src/functions/secret-permissions/New-TssSecretPermission.ps1
@@ -106,7 +106,8 @@ function New-TssSecretPermission {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.SecretPermissions.Permission]$restResponse
+                        $typeProps = [Thycotic.PowerShell.SecretPermissions.Permission].GetProperties().Name
+                        [Thycotic.PowerShell.SecretPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
                     }
                 } else {
                     Write-Error "Secret [$secret] has InheritPermissions enabled, use -Force parameter to break inheritance."

--- a/src/functions/secret-permissions/New-TssSecretPermission.ps1
+++ b/src/functions/secret-permissions/New-TssSecretPermission.ps1
@@ -106,8 +106,7 @@ function New-TssSecretPermission {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.SecretPermissions.Permission].GetProperties().Name
-                        [Thycotic.PowerShell.SecretPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.SecretPermissions.Permission](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretPermissions.Permission]))
                     }
                 } else {
                     Write-Error "Secret [$secret] has InheritPermissions enabled, use -Force parameter to break inheritance."

--- a/src/functions/secret-permissions/Search-TssSecretPermission.ps1
+++ b/src/functions/secret-permissions/Search-TssSecretPermission.ps1
@@ -118,7 +118,7 @@ function Search-TssSecretPermission {
                 Write-Warning 'No SecretPermission found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.SecretPermissions.Permission[]]$restResponse.records
+                [Thycotic.PowerShell.SecretPermissions.Permission[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.SecretPermissions.Permission]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/secret-permissions/Update-TssSecretPermission.ps1
+++ b/src/functions/secret-permissions/Update-TssSecretPermission.ps1
@@ -80,7 +80,8 @@ function Update-TssSecretPermission {
                     }
                 }
                 if ($restResponse) {
-                    [Thycotic.PowerShell.SecretPermissions.Permission]$restResponse
+                    $typeProps = [Thycotic.PowerShell.SecretPermissions.Permission].GetProperties().Name
+                    [Thycotic.PowerShell.SecretPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secret-permissions/Update-TssSecretPermission.ps1
+++ b/src/functions/secret-permissions/Update-TssSecretPermission.ps1
@@ -80,8 +80,7 @@ function Update-TssSecretPermission {
                     }
                 }
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.SecretPermissions.Permission].GetProperties().Name
-                    [Thycotic.PowerShell.SecretPermissions.Permission]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretPermissions.Permission](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretPermissions.Permission]))
                 }
             }
         } else {

--- a/src/functions/secret-policies/Get-TssSecretPolicy.ps1
+++ b/src/functions/secret-policies/Get-TssSecretPolicy.ps1
@@ -65,12 +65,7 @@ function Get-TssSecretPolicy {
                 }
 
                 if ($restResponse) {
-                    # Ignore the nuull values while converting it to Thycotic.PowerShell.SecretPolicies 
-                    $restResponse | ForEach-Object {
-                        $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                        $_ | Select-Object -Property $NonEmptyProperties
-                    }
-                    [Thycotic.PowerShell.SecretPolicies.Policy[]]$NonEmptyProperties
+                    [Thycotic.PowerShell.SecretPolicies.Policy[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretPolicies.Policy]))
                 }
             }
         } else {

--- a/src/functions/secret-policies/Get-TssSecretPolicyStub.ps1
+++ b/src/functions/secret-policies/Get-TssSecretPolicyStub.ps1
@@ -52,7 +52,7 @@ function Get-TssSecretPolicyStub {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.SecretPolicies.Policy[]]$restResponse
+                    [Thycotic.PowerShell.SecretPolicies.Policy[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretPolicies.Policy]))
                 }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-policies/New-TssSecretPolicy.ps1
+++ b/src/functions/secret-policies/New-TssSecretPolicy.ps1
@@ -108,8 +108,7 @@ function New-TssSecretPolicy {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.SecretPolicies.Policy].GetProperties().Name
-                [Thycotic.PowerShell.SecretPolicies.Policy]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.SecretPolicies.Policy](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretPolicies.Policy]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-policies/New-TssSecretPolicy.ps1
+++ b/src/functions/secret-policies/New-TssSecretPolicy.ps1
@@ -108,7 +108,8 @@ function New-TssSecretPolicy {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.SecretPolicies.Policy]$restResponse
+                $typeProps = [Thycotic.PowerShell.SecretPolicies.Policy].GetProperties().Name
+                [Thycotic.PowerShell.SecretPolicies.Policy]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-policies/Search-TssSecretPolicy.ps1
+++ b/src/functions/secret-policies/Search-TssSecretPolicy.ps1
@@ -80,8 +80,7 @@ function Search-TssSecretPolicy {
                 Write-Warning "No SecretPolicy found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.SecretPolicies.Summary].GetProperties().Name
-                [Thycotic.PowerShell.SecretPolicies.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.SecretPolicies.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.SecretPolicies.Summary]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-policies/Search-TssSecretPolicy.ps1
+++ b/src/functions/secret-policies/Search-TssSecretPolicy.ps1
@@ -80,7 +80,8 @@ function Search-TssSecretPolicy {
                 Write-Warning "No SecretPolicy found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.SecretPolicies.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.SecretPolicies.Summary].GetProperties().Name
+                [Thycotic.PowerShell.SecretPolicies.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/secret-templates/Get-TssSecretTemplate.ps1
+++ b/src/functions/secret-templates/Get-TssSecretTemplate.ps1
@@ -61,11 +61,7 @@ function Get-TssSecretTemplate {
                 }
 
                 if ($restResponse) {
-                        $restResponse | ForEach-Object {
-                            $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                            $_ | Select-Object -Property $NonEmptyProperties
-                        }
-                        [Thycotic.PowerShell.SecretTemplates.Template]$NonEmptyProperties
+                    [Thycotic.PowerShell.SecretTemplates.Template](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretTemplates.Template]))
                 }
             }
         } else {

--- a/src/functions/secret-templates/Get-TssSecretTemplateFolder.ps1
+++ b/src/functions/secret-templates/Get-TssSecretTemplateFolder.ps1
@@ -59,7 +59,7 @@ function Get-TssSecretTemplateFolder {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.SecretTemplates.View[]]$restResponse
+                    [Thycotic.PowerShell.SecretTemplates.View[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretTemplates.View]))
                 }
             }
         } else {

--- a/src/functions/secret-templates/New-TssSecretTemplate.ps1
+++ b/src/functions/secret-templates/New-TssSecretTemplate.ps1
@@ -112,7 +112,8 @@ function New-TssSecretTemplate {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.SecretTemplates.Template]$restResponse
+                $typeProps = [Thycotic.PowerShell.SecretTemplates.Template].GetProperties().Name
+                [Thycotic.PowerShell.SecretTemplates.Template]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/secret-templates/New-TssSecretTemplate.ps1
+++ b/src/functions/secret-templates/New-TssSecretTemplate.ps1
@@ -112,8 +112,7 @@ function New-TssSecretTemplate {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.SecretTemplates.Template].GetProperties().Name
-                [Thycotic.PowerShell.SecretTemplates.Template]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.SecretTemplates.Template](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretTemplates.Template]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/secret-templates/Search-TssSecretTemplate.ps1
+++ b/src/functions/secret-templates/Search-TssSecretTemplate.ps1
@@ -91,7 +91,8 @@ function Search-TssSecretTemplate {
                 Write-Warning 'No Secret Templates found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.SecretTemplates.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.SecretTemplates.Summary].GetProperties().Name
+                [Thycotic.PowerShell.SecretTemplates.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
 
         } else {

--- a/src/functions/secret-templates/Search-TssSecretTemplate.ps1
+++ b/src/functions/secret-templates/Search-TssSecretTemplate.ps1
@@ -91,8 +91,7 @@ function Search-TssSecretTemplate {
                 Write-Warning 'No Secret Templates found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.SecretTemplates.Summary].GetProperties().Name
-                [Thycotic.PowerShell.SecretTemplates.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.SecretTemplates.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.SecretTemplates.Summary]))
             }
 
         } else {

--- a/src/functions/secret-templates/Update-TssSecretTemplateField.ps1
+++ b/src/functions/secret-templates/Update-TssSecretTemplateField.ps1
@@ -66,8 +66,7 @@ function Update-TssSecretTemplateField {
                     . $ErrorHandling $err
                 }
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.SecretTemplates.Field].GetProperties().Name
-                    [Thycotic.PowerShell.SecretTemplates.Field]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.SecretTemplates.Field](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.SecretTemplates.Field]))
                 }
             }
         } else {

--- a/src/functions/secret-templates/Update-TssSecretTemplateField.ps1
+++ b/src/functions/secret-templates/Update-TssSecretTemplateField.ps1
@@ -66,7 +66,8 @@ function Update-TssSecretTemplateField {
                     . $ErrorHandling $err
                 }
                 if ($restResponse) {
-                    [Thycotic.PowerShell.SecretTemplates.Field]$restResponse
+                    $typeProps = [Thycotic.PowerShell.SecretTemplates.Field].GetProperties().Name
+                    [Thycotic.PowerShell.SecretTemplates.Field]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secrets/Get-TssSecret.ps1
+++ b/src/functions/secrets/Get-TssSecret.ps1
@@ -190,8 +190,7 @@ function Get-TssSecret {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Secrets.Secret].GetProperties().Name
-                        [Thycotic.PowerShell.Secrets.Secret]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Secrets.Secret](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.Secret]))
                     }
                 }
             }
@@ -238,8 +237,7 @@ function Get-TssSecret {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Secrets.Secret].GetProperties().Name
-                        [Thycotic.PowerShell.Secrets.Secret]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Secrets.Secret](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.Secret]))
                     }
                 }
             }

--- a/src/functions/secrets/Get-TssSecret.ps1
+++ b/src/functions/secrets/Get-TssSecret.ps1
@@ -190,7 +190,8 @@ function Get-TssSecret {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Secrets.Secret]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Secrets.Secret].GetProperties().Name
+                        [Thycotic.PowerShell.Secrets.Secret]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }
@@ -237,7 +238,8 @@ function Get-TssSecret {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Secrets.Secret]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Secrets.Secret].GetProperties().Name
+                        [Thycotic.PowerShell.Secrets.Secret]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/secrets/Get-TssSecretAudit.ps1
+++ b/src/functions/secrets/Get-TssSecretAudit.ps1
@@ -73,7 +73,8 @@ function Get-TssSecretAudit {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Secrets.Audit[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Secrets.Audit].GetProperties().Name
+                    [Thycotic.PowerShell.Secrets.Audit[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secrets/Get-TssSecretAudit.ps1
+++ b/src/functions/secrets/Get-TssSecretAudit.ps1
@@ -73,8 +73,7 @@ function Get-TssSecretAudit {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Secrets.Audit].GetProperties().Name
-                    [Thycotic.PowerShell.Secrets.Audit[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Secrets.Audit[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Secrets.Audit]))
                 }
             }
         } else {

--- a/src/functions/secrets/Get-TssSecretHeartbeatStatus.ps1
+++ b/src/functions/secrets/Get-TssSecretHeartbeatStatus.ps1
@@ -61,7 +61,8 @@ function Get-TssSecretHeartbeatStatus {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Secrets.HeartbeatStatus]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Secrets.HeartbeatStatus].GetProperties().Name
+                    [Thycotic.PowerShell.Secrets.HeartbeatStatus]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secrets/Get-TssSecretHeartbeatStatus.ps1
+++ b/src/functions/secrets/Get-TssSecretHeartbeatStatus.ps1
@@ -61,8 +61,7 @@ function Get-TssSecretHeartbeatStatus {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Secrets.HeartbeatStatus].GetProperties().Name
-                    [Thycotic.PowerShell.Secrets.HeartbeatStatus]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Secrets.HeartbeatStatus](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.HeartbeatStatus]))
                 }
             }
         } else {

--- a/src/functions/secrets/Get-TssSecretPasswordStatus.ps1
+++ b/src/functions/secrets/Get-TssSecretPasswordStatus.ps1
@@ -62,8 +62,7 @@ function Get-TssSecretPasswordStatus {
                 }
 
                 if ($restResponse.status -ne 'None') {
-                    $typeProps = [Thycotic.PowerShell.Secrets.PasswordStatus].GetProperties().Name
-                    [Thycotic.PowerShell.Secrets.PasswordStatus]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Secrets.PasswordStatus](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.PasswordStatus]))
                 } else {
                     Write-Host "No active password change found on Secret [$secret]"
                 }

--- a/src/functions/secrets/Get-TssSecretPasswordStatus.ps1
+++ b/src/functions/secrets/Get-TssSecretPasswordStatus.ps1
@@ -62,7 +62,8 @@ function Get-TssSecretPasswordStatus {
                 }
 
                 if ($restResponse.status -ne 'None') {
-                    [Thycotic.PowerShell.Secrets.PasswordStatus]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Secrets.PasswordStatus].GetProperties().Name
+                    [Thycotic.PowerShell.Secrets.PasswordStatus]($restResponse | Select-Object -Property $typeProps)
                 } else {
                     Write-Host "No active password change found on Secret [$secret]"
                 }

--- a/src/functions/secrets/Get-TssSecretSetting.ps1
+++ b/src/functions/secrets/Get-TssSecretSetting.ps1
@@ -61,11 +61,7 @@ function Get-TssSecretSetting {
                 }
 
                 if ($restResponse) {
-					$restResponse | ForEach-Object {
-                        $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                        $_ | Select-Object -Property $NonEmptyProperties
-                    }
-                    [Thycotic.PowerShell.Secrets.DetailSettings]$NonEmptyProperties
+                    [Thycotic.PowerShell.Secrets.DetailSettings](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.DetailSettings]))
                 }
             }
         } else {

--- a/src/functions/secrets/Get-TssSecretState.ps1
+++ b/src/functions/secrets/Get-TssSecretState.ps1
@@ -61,8 +61,7 @@ function Get-TssSecretState {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Secrets.DetailState].GetProperties().Name
-                    [Thycotic.PowerShell.Secrets.DetailState]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Secrets.DetailState](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.DetailState]))
                 }
             }
         } else {

--- a/src/functions/secrets/Get-TssSecretState.ps1
+++ b/src/functions/secrets/Get-TssSecretState.ps1
@@ -61,7 +61,8 @@ function Get-TssSecretState {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Secrets.DetailState]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Secrets.DetailState].GetProperties().Name
+                    [Thycotic.PowerShell.Secrets.DetailState]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secrets/Get-TssSecretStub.ps1
+++ b/src/functions/secrets/Get-TssSecretStub.ps1
@@ -78,7 +78,8 @@ function Get-TssSecretStub {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Secrets.Secret]$restResponse
+                $typeProps = [Thycotic.PowerShell.Secrets.Secret].GetProperties().Name
+                [Thycotic.PowerShell.Secrets.Secret]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/secrets/Get-TssSecretStub.ps1
+++ b/src/functions/secrets/Get-TssSecretStub.ps1
@@ -78,8 +78,7 @@ function Get-TssSecretStub {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Secrets.Secret].GetProperties().Name
-                [Thycotic.PowerShell.Secrets.Secret]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Secrets.Secret](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.Secret]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/secrets/Get-TssSecretSummary.ps1
+++ b/src/functions/secrets/Get-TssSecretSummary.ps1
@@ -61,7 +61,8 @@ function Get-TssSecretSummary {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Secrets.Summary]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Secrets.Summary].GetProperties().Name
+                    [Thycotic.PowerShell.Secrets.Summary]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/secrets/Get-TssSecretSummary.ps1
+++ b/src/functions/secrets/Get-TssSecretSummary.ps1
@@ -61,8 +61,7 @@ function Get-TssSecretSummary {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Secrets.Summary].GetProperties().Name
-                    [Thycotic.PowerShell.Secrets.Summary]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Secrets.Summary](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.Summary]))
                 }
             }
         } else {

--- a/src/functions/secrets/New-TssSecret.ps1
+++ b/src/functions/secrets/New-TssSecret.ps1
@@ -84,8 +84,7 @@ function New-TssSecret {
                 . $ErrorHandling $err
             }
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Secrets.Secret].GetProperties().Name
-                [Thycotic.PowerShell.Secrets.Secret]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Secrets.Secret](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.Secret]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/secrets/New-TssSecret.ps1
+++ b/src/functions/secrets/New-TssSecret.ps1
@@ -84,7 +84,8 @@ function New-TssSecret {
                 . $ErrorHandling $err
             }
             if ($restResponse) {
-                [Thycotic.PowerShell.Secrets.Secret]$restResponse
+                $typeProps = [Thycotic.PowerShell.Secrets.Secret].GetProperties().Name
+                [Thycotic.PowerShell.Secrets.Secret]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/secrets/Remove-TssSecret.ps1
+++ b/src/functions/secrets/Remove-TssSecret.ps1
@@ -61,8 +61,7 @@ function Remove-TssSecret {
                     }
 
                     if ($restResponse) {
-                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
-                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
+                        [Thycotic.PowerShell.Common.Delete](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Common.Delete]))
                     }
                 }
             }

--- a/src/functions/secrets/Remove-TssSecret.ps1
+++ b/src/functions/secrets/Remove-TssSecret.ps1
@@ -61,7 +61,8 @@ function Remove-TssSecret {
                     }
 
                     if ($restResponse) {
-                        [Thycotic.PowerShell.Common.Delete]$restResponse
+                        $typeProps = [Thycotic.PowerShell.Common.Delete].GetProperties().Name
+                        [Thycotic.PowerShell.Common.Delete]($restResponse | Select-Object -Property $typeProps)
                     }
                 }
             }

--- a/src/functions/secrets/Search-TssSecret.ps1
+++ b/src/functions/secrets/Search-TssSecret.ps1
@@ -271,11 +271,7 @@ function Search-TssSecret {
             }
 
             if ($restResponse.records) {
-                $restResponse | ForEach-Object {
-                    $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                    ($_ | Select-Object -Property $NonEmptyProperties).records
-                }
-                [Thycotic.PowerShell.Secrets.Summary[]]$NonEmptyProperties.records
+                [Thycotic.PowerShell.Secrets.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Secrets.Summary]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/secrets/Update-TssSecret.ps1
+++ b/src/functions/secrets/Update-TssSecret.ps1
@@ -114,7 +114,7 @@ function Update-TssSecret {
                 }
 
                 if ($updateResponse.id -eq $secretId) {
-                    [Thycotic.PowerShell.Secrets.Secret]$updateResponse
+                    [Thycotic.PowerShell.Secrets.Secret](. $FilterTssResponse $updateResponse ([Thycotic.PowerShell.Secrets.Secret]))
                 }
             }
         } else {

--- a/src/functions/server-nodes/Search-TssServerNode.ps1
+++ b/src/functions/server-nodes/Search-TssServerNode.ps1
@@ -55,8 +55,7 @@ function Search-TssServerNode {
                 Write-Warning "No records found"
             }
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.ServerNodes.List].GetProperties().Name
-                [Thycotic.PowerShell.ServerNodes.List[]]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.ServerNodes.List[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.ServerNodes.List]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/server-nodes/Search-TssServerNode.ps1
+++ b/src/functions/server-nodes/Search-TssServerNode.ps1
@@ -55,7 +55,8 @@ function Search-TssServerNode {
                 Write-Warning "No records found"
             }
             if ($restResponse) {
-                [Thycotic.PowerShell.ServerNodes.List[]]$restResponse
+                $typeProps = [Thycotic.PowerShell.ServerNodes.List].GetProperties().Name
+                [Thycotic.PowerShell.ServerNodes.List[]]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/sites/Get-TssSite.ps1
+++ b/src/functions/sites/Get-TssSite.ps1
@@ -57,8 +57,7 @@ function Get-TssSite {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Common.Site].GetProperties().Name
-                [Thycotic.PowerShell.Common.Site[]]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Common.Site[]](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Common.Site]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/sites/Get-TssSite.ps1
+++ b/src/functions/sites/Get-TssSite.ps1
@@ -57,7 +57,8 @@ function Get-TssSite {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Common.Site[]]$restResponse
+                $typeProps = [Thycotic.PowerShell.Common.Site].GetProperties().Name
+                [Thycotic.PowerShell.Common.Site[]]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/users/Find-TssUser.ps1
+++ b/src/functions/users/Find-TssUser.ps1
@@ -102,12 +102,7 @@ function Find-TssUser {
                 Write-Warning 'No Users found'
             }
             if ($restResponse.records) {
-                $restResponse | ForEach-Object {
-                    $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                    $_ | Select-Object -Property $NonEmptyProperties
-            }
-
-                foreach ($user in $NonEmptyProperties.records) {
+                foreach ($user in $restResponse.records) {
                     $parsedValue = $user.value.Split('-', 2).Trim()
                     [Thycotic.PowerShell.Users.Lookup]@{
                         Id       = $user.id

--- a/src/functions/users/Get-TssUser.ps1
+++ b/src/functions/users/Get-TssUser.ps1
@@ -64,7 +64,8 @@ function Get-TssUser {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Users.User]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Users.User].GetProperties().Name
+                    [Thycotic.PowerShell.Users.User]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/users/Get-TssUser.ps1
+++ b/src/functions/users/Get-TssUser.ps1
@@ -64,8 +64,7 @@ function Get-TssUser {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Users.User].GetProperties().Name
-                    [Thycotic.PowerShell.Users.User]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Users.User](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Users.User]))
                 }
             }
         } else {

--- a/src/functions/users/Get-TssUserAudit.ps1
+++ b/src/functions/users/Get-TssUserAudit.ps1
@@ -62,8 +62,7 @@ function Get-TssUserAudit {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.Users.AuditSummary].GetProperties().Name
-                    [Thycotic.PowerShell.Users.AuditSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Users.AuditSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Users.AuditSummary]))
                 }
             }
         } else {

--- a/src/functions/users/Get-TssUserAudit.ps1
+++ b/src/functions/users/Get-TssUserAudit.ps1
@@ -62,7 +62,8 @@ function Get-TssUserAudit {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Users.AuditSummary[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Users.AuditSummary].GetProperties().Name
+                    [Thycotic.PowerShell.Users.AuditSummary[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/users/Get-TssUserGroup.ps1
+++ b/src/functions/users/Get-TssUserGroup.ps1
@@ -65,7 +65,7 @@ function Get-TssUserGroup {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Groups.UserSummary[]]$restREsponse.records
+                    [Thycotic.PowerShell.Groups.UserSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Groups.UserSummary]))
                 }
             }
         } else {

--- a/src/functions/users/Get-TssUserOwner.ps1
+++ b/src/functions/users/Get-TssUserOwner.ps1
@@ -65,7 +65,8 @@ function Get-TssUserOwner {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Users.OwnerSummary[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Users.OwnerSummary].GetProperties().Name
+                    [Thycotic.PowerShell.Users.OwnerSummary[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/users/Get-TssUserOwner.ps1
+++ b/src/functions/users/Get-TssUserOwner.ps1
@@ -65,8 +65,7 @@ function Get-TssUserOwner {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.Users.OwnerSummary].GetProperties().Name
-                    [Thycotic.PowerShell.Users.OwnerSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Users.OwnerSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Users.OwnerSummary]))
                 }
             }
         } else {

--- a/src/functions/users/Get-TssUserRole.ps1
+++ b/src/functions/users/Get-TssUserRole.ps1
@@ -63,8 +63,7 @@ function Get-TssUserRole {
                 }
 
                 if ($restResponse.records.Count -gt 0) {
-                    $typeProps = [Thycotic.PowerShell.Users.RoleSummary].GetProperties().Name
-                    [Thycotic.PowerShell.Users.RoleSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Users.RoleSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Users.RoleSummary]))
                 } else {
                     Write-Warning "User ID [$user] not found"
                 }

--- a/src/functions/users/Get-TssUserRole.ps1
+++ b/src/functions/users/Get-TssUserRole.ps1
@@ -63,7 +63,8 @@ function Get-TssUserRole {
                 }
 
                 if ($restResponse.records.Count -gt 0) {
-                    [Thycotic.PowerShell.Users.RoleSummary[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Users.RoleSummary].GetProperties().Name
+                    [Thycotic.PowerShell.Users.RoleSummary[]]($restResponse.records | Select-Object -Property $typeProps)
                 } else {
                     Write-Warning "User ID [$user] not found"
                 }

--- a/src/functions/users/Get-TssUserRoleAssigned.ps1
+++ b/src/functions/users/Get-TssUserRoleAssigned.ps1
@@ -63,8 +63,7 @@ function Get-TssUserRoleAssigned {
                 }
 
                 if ($restResponse.records) {
-                    $typeProps = [Thycotic.PowerShell.Users.UserRoleSummary].GetProperties().Name
-                    [Thycotic.PowerShell.Users.UserRoleSummary[]]($restResponse.records | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Users.UserRoleSummary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Users.UserRoleSummary]))
                 }
             }
         } else {

--- a/src/functions/users/Get-TssUserRoleAssigned.ps1
+++ b/src/functions/users/Get-TssUserRoleAssigned.ps1
@@ -63,7 +63,8 @@ function Get-TssUserRoleAssigned {
                 }
 
                 if ($restResponse.records) {
-                    [Thycotic.PowerShell.Users.UserRoleSummary[]]$restResponse.records
+                    $typeProps = [Thycotic.PowerShell.Users.UserRoleSummary].GetProperties().Name
+                    [Thycotic.PowerShell.Users.UserRoleSummary[]]($restResponse.records | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/users/New-TssUser.ps1
+++ b/src/functions/users/New-TssUser.ps1
@@ -117,7 +117,8 @@ function New-TssUser {
             }
 
             if ($restResponse) {
-                [Thycotic.PowerShell.Users.User]$restResponse
+                $typeProps = [Thycotic.PowerShell.Users.User].GetProperties().Name
+                [Thycotic.PowerShell.Users.User]($restResponse | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/users/New-TssUser.ps1
+++ b/src/functions/users/New-TssUser.ps1
@@ -117,8 +117,7 @@ function New-TssUser {
             }
 
             if ($restResponse) {
-                $typeProps = [Thycotic.PowerShell.Users.User].GetProperties().Name
-                [Thycotic.PowerShell.Users.User]($restResponse | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Users.User](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Users.User]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/users/Search-TssUser.ps1
+++ b/src/functions/users/Search-TssUser.ps1
@@ -102,7 +102,8 @@ function Search-TssUser {
                 Write-Warning 'No Users found'
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.Users.Summary[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.Users.Summary].GetProperties().Name
+                [Thycotic.PowerShell.Users.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/users/Search-TssUser.ps1
+++ b/src/functions/users/Search-TssUser.ps1
@@ -102,8 +102,7 @@ function Search-TssUser {
                 Write-Warning 'No Users found'
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.Users.Summary].GetProperties().Name
-                [Thycotic.PowerShell.Users.Summary[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.Users.Summary[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.Users.Summary]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/users/Show-TssCurrentUser.ps1
+++ b/src/functions/users/Show-TssCurrentUser.ps1
@@ -60,11 +60,7 @@ function Show-TssCurrentUser {
             }
 
             if ($restResponse) {
-                $restResponse | ForEach-Object {
-                    $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
-                    $_ | Select-Object -Property $NonEmptyProperties
-            }
-            [Thycotic.PowerShell.Users.CurrentUser]$NonEmptyProperties
+                [Thycotic.PowerShell.Users.CurrentUser](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Users.CurrentUser]))
             }
         } else {
             Write-Warning 'No valid session found'

--- a/src/functions/users/Update-TssUser.ps1
+++ b/src/functions/users/Update-TssUser.ps1
@@ -68,7 +68,8 @@ function Update-TssUser {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Users.User]$restResponse
+                    $typeProps = [Thycotic.PowerShell.Users.User].GetProperties().Name
+                    [Thycotic.PowerShell.Users.User]($restResponse | Select-Object -Property $typeProps)
                 }
             }
         } else {

--- a/src/functions/users/Update-TssUser.ps1
+++ b/src/functions/users/Update-TssUser.ps1
@@ -68,8 +68,7 @@ function Update-TssUser {
                 }
 
                 if ($restResponse) {
-                    $typeProps = [Thycotic.PowerShell.Users.User].GetProperties().Name
-                    [Thycotic.PowerShell.Users.User]($restResponse | Select-Object -Property $typeProps)
+                    [Thycotic.PowerShell.Users.User](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Users.User]))
                 }
             }
         } else {

--- a/src/functions/workflow-templates/Search-TssWorkflowTemplate.ps1
+++ b/src/functions/workflow-templates/Search-TssWorkflowTemplate.ps1
@@ -74,7 +74,8 @@ function Search-TssWorkflowTemplate {
                 Write-Warning "No Workflow(s) found"
             }
             if ($restResponse.records) {
-                [Thycotic.PowerShell.WorkflowTemplates.Detail[]]$restResponse.records
+                $typeProps = [Thycotic.PowerShell.WorkflowTemplates.Detail].GetProperties().Name
+                [Thycotic.PowerShell.WorkflowTemplates.Detail[]]($restResponse.records | Select-Object -Property $typeProps)
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/functions/workflow-templates/Search-TssWorkflowTemplate.ps1
+++ b/src/functions/workflow-templates/Search-TssWorkflowTemplate.ps1
@@ -74,8 +74,7 @@ function Search-TssWorkflowTemplate {
                 Write-Warning "No Workflow(s) found"
             }
             if ($restResponse.records) {
-                $typeProps = [Thycotic.PowerShell.WorkflowTemplates.Detail].GetProperties().Name
-                [Thycotic.PowerShell.WorkflowTemplates.Detail[]]($restResponse.records | Select-Object -Property $typeProps)
+                [Thycotic.PowerShell.WorkflowTemplates.Detail[]](. $FilterTssResponse $restResponse.records ([Thycotic.PowerShell.WorkflowTemplates.Detail]))
             }
         } else {
             Write-Warning "No valid session found"

--- a/src/parts/FilterTssResponse.ps1
+++ b/src/parts/FilterTssResponse.ps1
@@ -1,0 +1,21 @@
+[cmdletbinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    $Response,
+    [Parameter(Mandatory, Position = 1)]
+    [type]$TargetType
+)
+
+if ($null -eq $Response) { return }
+
+$typeProps = $TargetType.GetProperties().Name
+$sample = if ($Response -is [array]) { $Response[0] } else { $Response }
+
+if ($null -ne $sample) {
+    $extraProps = $sample.PSObject.Properties.Name | Where-Object { $_ -notin $typeProps }
+    if ($extraProps) {
+        Write-Verbose "[$($TargetType.FullName)] New Properties detected - $($extraProps -join ', ')"
+    }
+}
+
+$Response | Select-Object -Property $typeProps

--- a/thycotic.secretserver.sln
+++ b/thycotic.secretserver.sln
@@ -1,0 +1,29 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thycotic.SecretServer", "src\Thycotic.SecretServer\Thycotic.SecretServer.csproj", "{D8D9D02D-BF8F-A811-B98B-835A1D7A10B7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D8D9D02D-BF8F-A811-B98B-835A1D7A10B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8D9D02D-BF8F-A811-B98B-835A1D7A10B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8D9D02D-BF8F-A811-B98B-835A1D7A10B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8D9D02D-BF8F-A811-B98B-835A1D7A10B7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D8D9D02D-BF8F-A811-B98B-835A1D7A10B7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3E275D5D-082F-4728-A048-AFF480905E4D}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Problem

Secret Server Cloud moved to a more dynamic release schedule, making it impossible to pre-release API changes into this module before they go live. When Secret Server adds new properties to REST API responses, those properties don't exist in the module's statically-defined C# classes. PowerShell's type cast (`[TargetType]$object`) silently drops unknown properties with no indication that anything was lost — causing confusing `Cannot convert value` errors for users on newer Secret Server Cloud builds.

This has caused a steady stream of reported issues: #383, #392, #396, #398, #399, #400, #406, #407, #408, #409, #410, #417, #418, #419 and several earlier ones (#277, #282, #283, #288, #319, #321, #333).

## Fix

All 119 REST-response casting sites now route through a new shared utility (`src/parts/FilterTssResponse.ps1`) before the type cast:

```powershell
# Before — silent drop of unknown properties
[Thycotic.PowerShell.Secrets.Secret]$restResponse

# After — filters unknown props, logs them via Write-Verbose, then casts
[Thycotic.PowerShell.Secrets.Secret](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Secrets.Secret]))
```

The utility:
1. Compares the response object's properties against the target class's known properties
2. If extra properties are found, emits a `Write-Verbose` message:
   `[Thycotic.PowerShell.Secrets.Secret] New Properties detected - iconId, concurrencyId, ...`
3. Strips the unknown properties via `Select-Object` before the cast proceeds

Verbose output is suppressed by default. Set `$VerbosePreference = 'Continue'` (or use `-Verbose` on any cmdlet) to see which new API fields the module doesn't yet support.

A follow-up commit migrates 17 additional cast sites that the initial pass missed (`Get-TssFolder`, `Get-TssSecretTemplate`, `Get-TssUserGroup`, `Search-TssSecret`, and others using either the buggy `$NonEmptyProperties` block or a direct cast that bypassed the centralised filter). Together they make the `Closes:` list below genuinely backed by code.

## Additional bug fixes bundled

This PR also picks up three small parameter/filter-builder bugs that were blocking the same 0.62.0 release:

- **#423** `Search-TssDirectoryServiceDomain` — `-DomainName` was declared `[int]`; restored to `[string]`.
- **#394** `Search-TssSecret` — `-ExtendedField` wrote `filter.extendedField` (no trailing `s`); the API expects `filter.extendedFields`, so the requested fields were silently ignored.
- **#415** `Find-TssSecret` — `-IncludeInactive` switch was declared but never threaded into the URL filter builder, so inactive secrets were always excluded.

## Design decisions

| Approach | Why not chosen |
|---|---|
| Add `[JsonExtensionData]` to C# classes | Requires modifying 174 class files + C# rebuild; adds noise to object exploration |
| Custom RestSharp `JsonConverter` | Tightly coupled to RestSharp internals; harder to maintain |
| Inline pattern per function (original PR approach) | 70+ duplicated sites; zero feedback on what was dropped |
| **Centralised `FilterTssResponse` utility** (chosen) | Single change point, follows existing `parts/` pattern, verbose logging included |

**Known limitation:** `Select-Object` filters top-level properties only. Nested objects (e.g., `Secret.Items[]`) are not recursively filtered. Nested class mismatches have not been a reported problem in practice and are out of scope for this change.

## Closes

Closes #383
Closes #392
Closes #394
Closes #396
Closes #398
Closes #399
Closes #400
Closes #406
Closes #407
Closes #408
Closes #409
Closes #410
Closes #415
Closes #417
Closes #418
Closes #419
Closes #423

## Testing

```powershell
# Enable verbose output to see new-property detection in action
$VerbosePreference = 'Continue'
$session = New-TssSession -SecretServer <url> -Credential <cred>
Get-TssSecret -TssSession $session -Id 1
# Expected if API has new fields: VERBOSE: [Thycotic.PowerShell.Secrets.Secret] New Properties detected - iconId, ...
# Expected output object: all previously-supported properties present and correct
```

Validated end-to-end against Secret Server 12.0.000022 with `tempScripts/Test-FilterTssResponseCoverage.ps1` (a 139-cmdlet behavioural sweep) — 70 read-only cmdlets return typed objects, no regressions vs the dev baseline. Verbose stream confirmed the strip behaviour: `[Thycotic.PowerShell.SecretTemplates.Template] New Properties detected - concurrencyId` (the exact field #400 named) and `[Thycotic.PowerShell.Secrets.Summary] New Properties detected - iconId, iconName` (#419's named field).

---
*Generated with [Claude Code](https://claude.ai/code)*
