### PR TITLE
fix: three small parameter/filter bugs for 0.62.0

### DIFF
--- a/src/functions/directory-services/Search-TssDirectoryServiceDomain.ps1
+++ b/src/functions/directory-services/Search-TssDirectoryServiceDomain.ps1
@@ -31,7 +31,7 @@ function Search-TssDirectoryServiceDomain {
 
         # Domain Name
         [Alias('Domain')]
-        [int]
+        [string]
         $DomainName,
 
         # Include inactive domains

--- a/src/functions/secrets/Find-TssSecret.ps1
+++ b/src/functions/secrets/Find-TssSecret.ps1
@@ -240,6 +240,7 @@ function Find-TssSecret {
                     'SharedWithMe' { $filters += "filter.onlySharedWithMe=$([boolean]$SharedWithMe)" }
                     'ExcludeDoubleLock' { $filters += "filter.allowDoubleLocks=$([boolean]$ExcludeDoubleLock)" }
                     'ExcludeActive' { $filters += "filter.includeActive=$([boolean]$ExcludeActive)" }
+                    'IncludeInactive' { $filters += "filter.includeInactive=$([boolean]$IncludeInactive)" }
                     'Scope' {
                         $filters += switch ($tssParams['Scope']) {
                             'All' { 'filter.scope=1' }

--- a/src/functions/secrets/Search-TssSecret.ps1
+++ b/src/functions/secrets/Search-TssSecret.ps1
@@ -238,7 +238,7 @@ function Search-TssSecret {
                 }
                 'ExtendedField' {
                     foreach ($v in $tssParams['ExtendedField']) {
-                        $filters += "filter.extendedField=$v"
+                        $filters += "filter.extendedFields=$v"
                     }
                 }
                 'PasswordTypeIds' {


### PR DESCRIPTION
Three small parameter/filter-builder bugs uncovered while validating PR #427 against a live Secret Server 12.0 lab. Each is a one-line fix backed by a user-filed issue that pinpoints the exact problem.

## Fixes

| Issue | File | Change |
|---|---|---|
| **#423** | `src/functions/directory-services/Search-TssDirectoryServiceDomain.ps1` | `-DomainName` was declared `[int]`; restored to `[string]` so the documented usage `-DomainName lab.local` no longer errors with `Cannot convert value '' to type System.Int32`. |
| **#394** | `src/functions/secrets/Search-TssSecret.ps1` | `-ExtendedField` wrote `filter.extendedField` (singular); the API expects `filter.extendedFields` (plural), so the requested fields were silently absent from responses. |
| **#415** | `src/functions/secrets/Find-TssSecret.ps1` | `-IncludeInactive` switch was declared in the param block but never threaded into the URL filter builder, so inactive secrets were always excluded regardless of the switch. |

Each reporter pinpointed the line in the original issue; no architectural changes required.

## Closes

Closes #394
Closes #415
Closes #423

## Testing

Validated via `tempScripts/Test-FilterTssResponseCoverage.ps1` on the Secret Server 12.0 lab — no regressions, all three cmdlets continue to return typed objects (`Search-TssDirectoryServiceDomain` → `DomainSummary`, `Search-TssSecret` → `Summary[]`, `Find-TssSecret` → `Lookup[]`). Module-level Pester suite green.

---
*Generated with [Claude Code](https://claude.ai/code)*