### PR TITLE
fix: Get-TssSecretHeartbeatStatus enum cast failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * REST response handling: all functions now strip unknown properties from API responses before casting to typed objects, preventing `Cannot convert value` errors when Secret Server Cloud adds new response fields not yet reflected in module class definitions. Unknown properties are reported via `Write-Verbose`. Fixes #392, #398, #400, #406, #407, #408, #409, #410, #419.
+* `Get-TssSecretHeartbeatStatus` - fix enum cast failure where the API returns a string status like `"Pending"`; `Thycotic.PowerShell.Secrets.HeartbeatStatus.Status` was self-typed instead of the `SecretHeartbeatStatus` enum. Fixes #433.
 
 ### New Stuff
 

--- a/src/Thycotic.SecretServer/classes/secrets/HeartbeatStatus.cs
+++ b/src/Thycotic.SecretServer/classes/secrets/HeartbeatStatus.cs
@@ -8,7 +8,7 @@ namespace Thycotic.PowerShell.Secrets
 {
     public class HeartbeatStatus
     {
-        public HeartbeatStatus Status { get; set; }
+        public SecretHeartbeatStatus Status { get; set; }
         public DateTime? LastHeartbeatCheck { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- `Thycotic.PowerShell.Secrets.HeartbeatStatus.Status` was self-typed (class self-reference) instead of the `SecretHeartbeatStatus` enum
- API returns the status as a string like `"Pending"`, which PowerShell cannot coerce into a class-typed property during the `[HeartbeatStatus]` cast
- Single-line C# fix; the existing `using Thycotic.PowerShell.Enums;` keeps the enum in scope

## Test plan
- [x] `Invoke-Build -File .\build.ps1 -Task . -Configuration Debug` — succeeds, no errors
- [x] `tests\runTests.ps1` — both `Get-TssSecretHeartbeatStatus.Tests.ps1` and `Start-TssSecretHeartbeat.Tests.ps1` pass
- [ ] Live smoke against SS 12.0: `Get-TssSecretHeartbeatStatus -TssSession $session -Id <id>` returns populated `Status` (enum) and `LastHeartbeatCheck`, no `Cannot convert value` error

Closes #433.