### PR TITLE
fix: Search-TssConfigurationBackupLog missing DbBackupLog type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * REST response handling: all functions now strip unknown properties from API responses before casting to typed objects, preventing `Cannot convert value` errors when Secret Server Cloud adds new response fields not yet reflected in module class definitions. Unknown properties are reported via `Write-Verbose`. Fixes #392, #398, #400, #406, #407, #408, #409, #410, #419.
 * `Get-TssSecretHeartbeatStatus` - fix enum cast failure where the API returns a string status like `"Pending"`; `Thycotic.PowerShell.Secrets.HeartbeatStatus.Status` was self-typed instead of the `SecretHeartbeatStatus` enum. Fixes #433.
+* `Search-TssConfigurationBackupLog` - fix `Unable to find type [Thycotic.PowerShell.Configuration.DbBackupLog]` error. The C# class file was named `BackupLog` while the cmdlet's `OutputType` and cast referenced `DbBackupLog`. Renamed the class (and its file) to match the cmdlet's contract. Fixes #431.
 
 ### New Stuff
 

--- a/src/Thycotic.SecretServer/classes/configurations/DbBackupLog.cs
+++ b/src/Thycotic.SecretServer/classes/configurations/DbBackupLog.cs
@@ -5,7 +5,7 @@ using System.Management.Automation.Runspaces;
 
 namespace Thycotic.PowerShell.Configuration
 {
-    public class BackupLog
+    public class DbBackupLog
     {
         public DateTime? BackupTime {get;set;}
         public string DisplayName {get;set;}


### PR DESCRIPTION
## Summary
- `Search-TssConfigurationBackupLog` declared `[OutputType('Thycotic.PowerShell.Configuration.DbBackupLog')]` and cast results to that type, but the compiled C# class was named `BackupLog`. The DLL never contained `DbBackupLog`, so the cmdlet failed at runtime with `Unable to find type [...DbBackupLog]`.
- Renamed the C# class (and its file) from `BackupLog` to `DbBackupLog` to match the cmdlet's declared contract. `DbBackupLog` is also more descriptive — the cmdlet specifically returns database backup logs.
- Single-class rename; no shape change.

## Test plan
- [x] `Invoke-Build -File .\build.ps1 -Task . -Configuration Debug` — succeeds, no errors
- [x] Pester test `Search-TssConfigurationBackupLog.Tests.ps1` was already asserting `OutputType -Be 'Thycotic.PowerShell.Configuration.DbBackupLog'` and now resolves correctly
- [ ] Live smoke against SS 11.0+: `Search-TssConfigurationBackupLog -TssSession $session` returns `Thycotic.PowerShell.Configuration.DbBackupLog` records (or "No backup logs found" warning), no `Unable to find type` error

Closes #431.