### PR TITLE
fix: New-TssSession preserve OTP leading zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * REST response handling: all functions now strip unknown properties from API responses before casting to typed objects, preventing `Cannot convert value` errors when Secret Server Cloud adds new response fields not yet reflected in module class definitions. Unknown properties are reported via `Write-Verbose`. Fixes #392, #398, #400, #406, #407, #408, #409, #410, #419.
 * `Get-TssSecretHeartbeatStatus` - fix enum cast failure where the API returns a string status like `"Pending"`; `Thycotic.PowerShell.Secrets.HeartbeatStatus.Status` was self-typed instead of the `SecretHeartbeatStatus` enum. Fixes #433.
 * `Search-TssConfigurationBackupLog` - fix `Unable to find type [Thycotic.PowerShell.Configuration.DbBackupLog]` error. The C# class file was named `BackupLog` while the cmdlet's `OutputType` and cast referenced `DbBackupLog`. Renamed the class (and its file) to match the cmdlet's contract. Fixes #431.
+* `New-TssSession` - `OtpCode` parameter is now `[string]` instead of `[int]`. OTP codes with leading zeros (e.g. `012345`) were being truncated by the integer coercion before reaching the API. Existing scripts that pass a numeric literal continue to work via PowerShell's implicit conversion. Fixes #316.
 
 ### New Stuff
 

--- a/src/Thycotic.SecretServer/cmdlets/private/NewTssApiToken.cs
+++ b/src/Thycotic.SecretServer/cmdlets/private/NewTssApiToken.cs
@@ -25,7 +25,7 @@ namespace Thycotic.SecretServer
         public string Password { get; set; }
 
         [Parameter(Position = 3)]
-        public int OtpCode { get; set; }
+        public string OtpCode { get; set; }
 
         [Parameter(Position = 4)]
         public SwitchParameter UseDefaultCredential { get; set; }

--- a/src/functions/authentication/New-TssSession.ps1
+++ b/src/functions/authentication/New-TssSession.ps1
@@ -37,10 +37,10 @@ function New-TssSession {
     Use the alias nts to create a session object
 
     .EXAMPLE
-    $session = New-TssSession -SecretServer https://vault.secretservercloud.com -Credential $cred -OtpCode 256380
+    $session = New-TssSession -SecretServer https://vault.secretservercloud.com -Credential $cred -OtpCode '012345'
     Show-TssCurrentUser -TssSession $session
 
-    Create a session object using OAuth2 credential and 2FA/OTP code. Then output the current user to verify toke is for the specific user credential.
+    Create a session object using OAuth2 credential and 2FA/OTP code. Then output the current user to verify toke is for the specific user credential. Quote the OtpCode to preserve any leading zeros.
 
     .EXAMPLE
     $session = New-TssSession -SecretServer https://vault.secretservercloud.com -Credential $cred
@@ -83,7 +83,7 @@ function New-TssSession {
 
         # Provide 2FA code
         [Parameter(ParameterSetName = 'new', Position = 2)]
-        [int]
+        [string]
         $OtpCode,
 
         # Specify Access Token


### PR DESCRIPTION
## Summary
- `OtpCode` was `[int]` on both `New-TssSession` and the underlying `NewTssApiToken` C# cmdlet
- PowerShell coerced `'012345'` to `12345` before the API ever saw it, stripping leading zeros and producing 401s
- Switched both declarations to `[string]`; the downstream call already emits `OtpCode.ToString()` so accepting a string is a no-op
- Numeric literals (`-OtpCode 256380`) keep working via implicit int-to-string conversion
- Updated the help example to quote the code so the correct pattern for zero-leading codes is visible

## Test plan
- [x] `Invoke-Build -File .\build.ps1 -Task . -Configuration Debug` — succeeds, no errors
- [ ] Live smoke: `New-TssSession -SecretServer 'https://...' -Credential $c -OtpCode '012345'` against an OTP-enabled user with a real 6-digit code starting with `0` — session returned, no 401

Closes #316.