### PR TITLE
fix: Get-TssConfiguration cast failure on SS 12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Get-TssSecretHeartbeatStatus` - fix enum cast failure where the API returns a string status like `"Pending"`; `Thycotic.PowerShell.Secrets.HeartbeatStatus.Status` was self-typed instead of the `SecretHeartbeatStatus` enum. Fixes #433.
 * `Search-TssConfigurationBackupLog` - fix `Unable to find type [Thycotic.PowerShell.Configuration.DbBackupLog]` error. The C# class file was named `BackupLog` while the cmdlet's `OutputType` and cast referenced `DbBackupLog`. Renamed the class (and its file) to match the cmdlet's contract. Fixes #431.
 * `New-TssSession` - `OtpCode` parameter is now `[string]` instead of `[int]`. OTP codes with leading zeros (e.g. `012345`) were being truncated by the integer coercion before reaching the API. Existing scripts that pass a numeric literal continue to work via PowerShell's implicit conversion. Fixes #316.
+* `Get-TssConfiguration` - fix `Cannot convert value ... to type Thycotic.PowerShell.Configuration.General` cast failure on SS 12.0. The outer `[General]` cast was applied to a response whose nested sub-objects (e.g. `email`, `applicationSettings`) still contained SS 12.0 fields not modeled by the C# classes. The cmdlet now constructs the `General` result by drilling into each known sub-object and running `FilterTssResponse` against it before assignment, so unknown nested fields are stripped instead of breaking the cast. Also handles the SS 12.0 rename of the `emailSettings` response property to `email`. Fixes #432.
 
 ### New Stuff
 

--- a/src/functions/configurations/Get-TssConfiguration.ps1
+++ b/src/functions/configurations/Get-TssConfiguration.ps1
@@ -75,33 +75,88 @@ function Get-TssConfiguration {
             }
 
             if ($restResponse) {
+                # SS 12.0 renamed 'emailSettings' to 'email' on the v1 configuration/general response; accept either.
+                $emailRaw = if ($null -ne $restResponse.email) { $restResponse.email } else { $restResponse.emailSettings }
+
                 switch ($Type) {
                     'All' {
-                        [Thycotic.PowerShell.Configuration.General](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.Configuration.General]))
+                        # Pre-filter each nested sub-object before assignment so unknown SS 12.0 fields
+                        # (e.g. EmailSettings.sendEmailMethod) don't break the outer [General] cast.
+                        $general = [Thycotic.PowerShell.Configuration.General]::new()
+                        if ($null -ne $restResponse.applicationSettings) {
+                            $general.ApplicationSettings = [Thycotic.PowerShell.Configuration.ApplicationSettings](. $FilterTssResponse $restResponse.applicationSettings ([Thycotic.PowerShell.Configuration.ApplicationSettings]))
+                        }
+                        if ($null -ne $emailRaw) {
+                            $general.Email = [Thycotic.PowerShell.Configuration.EmailSettings](. $FilterTssResponse $emailRaw ([Thycotic.PowerShell.Configuration.EmailSettings]))
+                        }
+                        if ($null -ne $restResponse.folders) {
+                            $general.Folders = [Thycotic.PowerShell.Configuration.Folders](. $FilterTssResponse $restResponse.folders ([Thycotic.PowerShell.Configuration.Folders]))
+                        }
+                        if ($null -ne $restResponse.launcherSettings) {
+                            $general.LauncherSettings = [Thycotic.PowerShell.Configuration.LauncherSettings](. $FilterTssResponse $restResponse.launcherSettings ([Thycotic.PowerShell.Configuration.LauncherSettings]))
+                        }
+                        if ($null -ne $restResponse.localUserPasswords) {
+                            $general.LocalUserPasswords = [Thycotic.PowerShell.Configuration.LocalUserPasswords](. $FilterTssResponse $restResponse.localUserPasswords ([Thycotic.PowerShell.Configuration.LocalUserPasswords]))
+                        }
+                        if ($null -ne $restResponse.permissionOptions) {
+                            $general.PermissionOptions = [Thycotic.PowerShell.Configuration.PermissionOptions](. $FilterTssResponse $restResponse.permissionOptions ([Thycotic.PowerShell.Configuration.PermissionOptions]))
+                        }
+                        if ($null -ne $restResponse.protocolHandlerSettings) {
+                            $general.ProtocolHandlerSettings = [Thycotic.PowerShell.Configuration.ProtocolHandlerSettings](. $FilterTssResponse $restResponse.protocolHandlerSettings ([Thycotic.PowerShell.Configuration.ProtocolHandlerSettings]))
+                        }
+                        if ($null -ne $restResponse.userExperience) {
+                            $general.UserExperience = [Thycotic.PowerShell.Configuration.UserExperience](. $FilterTssResponse $restResponse.userExperience ([Thycotic.PowerShell.Configuration.UserExperience]))
+                        }
+                        if ($null -ne $restResponse.userInterface) {
+                            $general.UserInterface = [Thycotic.PowerShell.Configuration.UserInterface](. $FilterTssResponse $restResponse.userInterface ([Thycotic.PowerShell.Configuration.UserInterface]))
+                        }
+                        if ($null -ne $restResponse.sessionRecording) {
+                            $general.sessionRecording = [Thycotic.PowerShell.Configuration.SessionRecording](. $FilterTssResponse $restResponse.sessionRecording ([Thycotic.PowerShell.Configuration.SessionRecording]))
+                        }
+                        if ($null -ne $restResponse.unlimitedAdmin) {
+                            $general.unlimitedAdmin = [Thycotic.PowerShell.Configuration.UnlimitedAdmin](. $FilterTssResponse $restResponse.unlimitedAdmin ([Thycotic.PowerShell.Configuration.UnlimitedAdmin]))
+                        }
+                        $general
                     }
                     'Application' {
-                        [Thycotic.PowerShell.Configuration.ApplicationSettings](. $FilterTssResponse $restResponse.applicationSettings ([Thycotic.PowerShell.Configuration.ApplicationSettings]))
+                        if ($null -ne $restResponse.applicationSettings) {
+                            [Thycotic.PowerShell.Configuration.ApplicationSettings](. $FilterTssResponse $restResponse.applicationSettings ([Thycotic.PowerShell.Configuration.ApplicationSettings]))
+                        }
                     }
                     'Email' {
-                        [Thycotic.PowerShell.Configuration.EmailSettings](. $FilterTssResponse $restResponse.emailSettings ([Thycotic.PowerShell.Configuration.EmailSettings]))
+                        if ($null -ne $emailRaw) {
+                            [Thycotic.PowerShell.Configuration.EmailSettings](. $FilterTssResponse $emailRaw ([Thycotic.PowerShell.Configuration.EmailSettings]))
+                        }
                     }
                     'Folders' {
-                        [Thycotic.PowerShell.Configuration.Folders](. $FilterTssResponse $restResponse.folders ([Thycotic.PowerShell.Configuration.Folders]))
+                        if ($null -ne $restResponse.folders) {
+                            [Thycotic.PowerShell.Configuration.Folders](. $FilterTssResponse $restResponse.folders ([Thycotic.PowerShell.Configuration.Folders]))
+                        }
                     }
                     'Launcher' {
-                        [Thycotic.PowerShell.Configuration.LauncherSettings](. $FilterTssResponse $restResponse.launcherSettings ([Thycotic.PowerShell.Configuration.LauncherSettings]))
+                        if ($null -ne $restResponse.launcherSettings) {
+                            [Thycotic.PowerShell.Configuration.LauncherSettings](. $FilterTssResponse $restResponse.launcherSettings ([Thycotic.PowerShell.Configuration.LauncherSettings]))
+                        }
                     }
                     'LocalUserPasswords' {
-                        [Thycotic.PowerShell.Configuration.LocalUserPasswords](. $FilterTssResponse $restResponse.localUserPasswords ([Thycotic.PowerShell.Configuration.LocalUserPasswords]))
+                        if ($null -ne $restResponse.localUserPasswords) {
+                            [Thycotic.PowerShell.Configuration.LocalUserPasswords](. $FilterTssResponse $restResponse.localUserPasswords ([Thycotic.PowerShell.Configuration.LocalUserPasswords]))
+                        }
                     }
                     'PermissionOptions' {
-                        [Thycotic.PowerShell.Configuration.PermissionOptions](. $FilterTssResponse $restResponse.permissionOptions ([Thycotic.PowerShell.Configuration.PermissionOptions]))
+                        if ($null -ne $restResponse.permissionOptions) {
+                            [Thycotic.PowerShell.Configuration.PermissionOptions](. $FilterTssResponse $restResponse.permissionOptions ([Thycotic.PowerShell.Configuration.PermissionOptions]))
+                        }
                     }
                     'UserExperience' {
-                        [Thycotic.PowerShell.Configuration.UserExperience](. $FilterTssResponse $restResponse.userExperience ([Thycotic.PowerShell.Configuration.UserExperience]))
+                        if ($null -ne $restResponse.userExperience) {
+                            [Thycotic.PowerShell.Configuration.UserExperience](. $FilterTssResponse $restResponse.userExperience ([Thycotic.PowerShell.Configuration.UserExperience]))
+                        }
                     }
                     'UserInterface' {
-                        [Thycotic.PowerShell.Configuration.UserInterface](. $FilterTssResponse $restResponse.userInterface ([Thycotic.PowerShell.Configuration.UserInterface]))
+                        if ($null -ne $restResponse.userInterface) {
+                            [Thycotic.PowerShell.Configuration.UserInterface](. $FilterTssResponse $restResponse.userInterface ([Thycotic.PowerShell.Configuration.UserInterface]))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Against SS 12.0 the cmdlet emits:
```
Cannot convert value "@{applicationSettings=; email=; ...}" to type "Thycotic.PowerShell.Configuration.General".
Error: "Cannot convert value "@{smtpServer=127.0.0.1; fromEmailAddress=...}" to type "Thycotic.PowerShell.Configuration.EmailSettings"."
```

Two root causes:

1. **Nested cast failure.** The outer `[General]` cast was applied to a response whose nested sub-objects (`email`, `applicationSettings`, ...) still contained SS 12.0 fields the C# classes don't model (e.g. `EmailSettings.sendEmailMethod`). `FilterTssResponse` only filtered the outer object — PowerShell's class coercion then choked on the unfiltered inner objects. Nested-property filtering was explicitly deferred in #427, so this PR addresses it at the cmdlet level for this one cmdlet rather than in the utility.

2. **Property rename.** SS 12.0 renamed the configuration/general response sub-property `emailSettings` to `email`, silently breaking the `-Type Email` branch (it dereferenced `$restResponse.emailSettings`, which was now `$null`).

## What changed
- Refactored the response handling in `Get-TssConfiguration` to construct the `General` result by drilling into each known sub-object and running `FilterTssResponse` against it before assignment.
- Each `-Type` branch was updated to follow the same pre-filter pattern.
- Email-related branches accept either `email` (SS 12.0) or `emailSettings` (legacy).
- The `-Type All` branch now also surfaces `sessionRecording`, `unlimitedAdmin`, and `protocolHandlerSettings` (which exist on the `General` C# class but were not being explicitly handled).
- No C# changes — the existing class shapes are preserved.

## Test plan
- [x] `Invoke-Build -File .\build.ps1 -Task . -Configuration Debug` — succeeds, no errors
- [x] PowerShell parser validates `Get-TssConfiguration.ps1` cleanly
- [ ] Live smoke against SS 12.0.000022 (labss01):
  - `Get-TssConfiguration -TssSession $session` returns a populated `[General]` object, no cast error
  - `Get-TssConfiguration -TssSession $session -Type Email` returns a populated `[EmailSettings]`
  - `Get-TssConfiguration -TssSession $session -Type Application/Folders/Launcher/LocalUserPasswords/PermissionOptions/UserExperience/UserInterface` each return populated sub-objects
- [ ] Live smoke against older SS (11.x) to confirm the legacy `emailSettings` path still works

Closes #432.