### PR TITLE
fix: Get-TssDirectoryServiceSyncStatus DomainStatus array cast failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `New-TssSession` - `OtpCode` parameter is now `[string]` instead of `[int]`. OTP codes with leading zeros (e.g. `012345`) were being truncated by the integer coercion before reaching the API. Existing scripts that pass a numeric literal continue to work via PowerShell's implicit conversion. Fixes #316.
 * `Get-TssConfiguration` - fix `Cannot convert value ... to type Thycotic.PowerShell.Configuration.General` cast failure on SS 12.0. The outer `[General]` cast was applied to a response whose nested sub-objects (e.g. `email`, `applicationSettings`) still contained SS 12.0 fields not modeled by the C# classes. The cmdlet now constructs the `General` result by drilling into each known sub-object and running `FilterTssResponse` against it before assignment, so unknown nested fields are stripped instead of breaking the cast. Also handles the SS 12.0 rename of the `emailSettings` response property to `email`. Fixes #432.
 * `New-TssSession` - authentication failures that return no error detail (e.g. TLS certificate rejection) now surface a descriptive message. When the certificate is likely the cause, the error text explicitly suggests adding `-SkipCertificateCheck`. Fixes #442.
+<<<<<<< HEAD
 * `Get-TssRpcPasswordType` - fix `Cannot convert value ... to type Thycotic.PowerShell.Rpc.PasswordTypeField` cast failure on SS 12.0. The outer `[PasswordType]` cast left the nested `fields` array as untyped `PSCustomObject` elements, which PowerShell could not coerce. The cmdlet now pre-coerces each `fields` element through `FilterTssResponse` before the outer cast. Fixes #440.
+=======
+* `Get-TssDirectoryServiceSyncStatus` - fix `Cannot convert value ... to type Thycotic.PowerShell.DirectoryServices.DomainSyncStatus` cast failure on SS 12.0. The outer `[SyncStatus]` cast left the nested `domainStatus` array as untyped `PSCustomObject` elements that PowerShell could not coerce. The cmdlet now pre-coerces each `domainStatus` element through `FilterTssResponse` before the outer cast. Same pattern as #440. Fixes #441.
+>>>>>>> eb679611 (fix: Get-TssDirectoryServiceSyncStatus DomainStatus array cast failure)
 
 ### New Stuff
 

--- a/src/functions/directory-services/Get-TssDirectoryServiceSyncStatus.ps1
+++ b/src/functions/directory-services/Get-TssDirectoryServiceSyncStatus.ps1
@@ -52,6 +52,16 @@ function Get-TssDirectoryServiceSyncStatus {
                 }
 
                 if ($restResponse) {
+                    # Pre-coerce each element of the nested DomainStatus array so SS 12.0's wider
+                    # DomainSyncStatus shape doesn't break the outer [SyncStatus] cast. Same pattern
+                    # as Get-TssRpcPasswordType (#440).
+                    if ($restResponse.domainStatus) {
+                        $restResponse.domainStatus = @(
+                            $restResponse.domainStatus | ForEach-Object {
+                                [Thycotic.PowerShell.DirectoryServices.DomainSyncStatus](. $FilterTssResponse $_ ([Thycotic.PowerShell.DirectoryServices.DomainSyncStatus]))
+                            }
+                        )
+                    }
                     [Thycotic.PowerShell.DirectoryServices.SyncStatus](. $FilterTssResponse $restResponse ([Thycotic.PowerShell.DirectoryServices.SyncStatus]))
                 }
         } else {


### PR DESCRIPTION
## Summary
On SS 12.0 the cmdlet emits:
```
Cannot convert value "..." to type "Thycotic.PowerShell.DirectoryServices.SyncStatus".
Error: "Cannot convert value "..." to type "Thycotic.PowerShell.DirectoryServices.DomainSyncStatus".
Error: "Cannot convert the "..." value of type "System.Management.Automation.PSCustomObject"
       to type "Thycotic.PowerShell.DirectoryServices.DomainSyncStatus"."
```

Same architectural shape as #440 (`Get-TssRpcPasswordType` / `PasswordTypeField[]`):
- `SyncStatus.DomainStatus` is `DomainSyncStatus[]`
- `FilterTssResponse` only filters the outer object's top-level properties (#427 design)
- The nested array survives unfiltered, and PowerShell's outer `[SyncStatus]` cast cannot coerce `PSCustomObject[]` into `DomainSyncStatus[]`

## What changed
- Pre-coerce each element of `$restResponse.domainStatus` through `FilterTssResponse` before the outer cast.
- After this pass, `domainStatus` holds typed `DomainSyncStatus[]` values, so the outer cast assigns the array as-is.

## Test plan
- [x] `Invoke-Build -File .\build.ps1 -Task . -Configuration Debug` — succeeds
- [x] PowerShell parser validates the cmdlet cleanly
- [ ] Live smoke against SS 12.0.000022: `Get-TssDirectoryServiceSyncStatus -TssSession $session` returns a populated `SyncStatus` with a populated `DomainStatus` collection — no cast error

Closes #441.