### PR TITLE
chore: prep 0.62.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.62.0 -- Unreleased
+## 0.62.0 -- 2026-05-15
 
 ### Breaking Changes
 
@@ -29,11 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `New-TssSession` - `OtpCode` parameter is now `[string]` instead of `[int]`. OTP codes with leading zeros (e.g. `012345`) were being truncated by the integer coercion before reaching the API. Existing scripts that pass a numeric literal continue to work via PowerShell's implicit conversion. Fixes #316.
 * `Get-TssConfiguration` - fix `Cannot convert value ... to type Thycotic.PowerShell.Configuration.General` cast failure on SS 12.0. The outer `[General]` cast was applied to a response whose nested sub-objects (e.g. `email`, `applicationSettings`) still contained SS 12.0 fields not modeled by the C# classes. The cmdlet now constructs the `General` result by drilling into each known sub-object and running `FilterTssResponse` against it before assignment, so unknown nested fields are stripped instead of breaking the cast. Also handles the SS 12.0 rename of the `emailSettings` response property to `email`. Fixes #432.
 * `New-TssSession` - authentication failures that return no error detail (e.g. TLS certificate rejection) now surface a descriptive message. When the certificate is likely the cause, the error text explicitly suggests adding `-SkipCertificateCheck`. Fixes #442.
-<<<<<<< HEAD
 * `Get-TssRpcPasswordType` - fix `Cannot convert value ... to type Thycotic.PowerShell.Rpc.PasswordTypeField` cast failure on SS 12.0. The outer `[PasswordType]` cast left the nested `fields` array as untyped `PSCustomObject` elements, which PowerShell could not coerce. The cmdlet now pre-coerces each `fields` element through `FilterTssResponse` before the outer cast. Fixes #440.
-=======
 * `Get-TssDirectoryServiceSyncStatus` - fix `Cannot convert value ... to type Thycotic.PowerShell.DirectoryServices.DomainSyncStatus` cast failure on SS 12.0. The outer `[SyncStatus]` cast left the nested `domainStatus` array as untyped `PSCustomObject` elements that PowerShell could not coerce. The cmdlet now pre-coerces each `domainStatus` element through `FilterTssResponse` before the outer cast. Same pattern as #440. Fixes #441.
->>>>>>> eb679611 (fix: Get-TssDirectoryServiceSyncStatus DomainStatus array cast failure)
 
 ### New Stuff
 


### PR DESCRIPTION
## Summary
Final prep for cutting the 0.62.0 release.

1. **Date-stamp the changelog** — `0.62.0 -- Unreleased` → `0.62.0 -- 2026-05-15`.
2. **Remove conflict markers in CHANGELOG.md** — PR #445 (#441 fix) was merged with an unresolved rebase conflict against PR #443 (#440 fix). The bullets for both `Get-TssRpcPasswordType` and `Get-TssDirectoryServiceSyncStatus` are preserved; the marker lines are removed.
3. **Module manifest** — `ModuleVersion = '0.62.0'` already in place; no change needed.

## 0.62.0 contents
- **Breaking:** RestSharp 110→112 (#442)
- **Bug fixes:** #316, #392, #398, #400, #406-#410, #419, #431, #432, #433, #440, #441, #442
- **New:** `-SkipCertificateCheck` switch, `FilterTssResponse` parts utility, bundled SDK CLI 1.6.1 (#382)

## After this merges
Maintainer runs `build.ps1 -Configuration Release -GalleryKey <key>` to:
- Publish to PSGallery
- Create the `v0.62.0` GitHub release (with `release.md` notes — see `.gitignore` `release*`)
- Compress + upload module zip + SHA256

## Test plan
- [x] No code changes — pure documentation
- [x] Module manifest version confirmed at `0.62.0`
- [ ] Maintainer cuts the release tag

Closes nothing on its own; gates the 0.62.0 release.