### PR TITLE
docs: regenerate per-type reference pages (docs/types)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This module provides a secure method that Secret Server Administrators and Users
 
 Secret Server provides a management tool for those privileged accounts. Thycotic.SecretServer module allows you to access those accounts securely and utilize them in your scripts and automation in a secure manner.
 
-## Classes
+## Classes and enums
 
 The module utilizes C# based classes to provide a unique object and type with each endpoint. In addition, certain classes may include Methods that provide "shortcuts" for performing specific actions in PowerShell or manipulating the object output by a function.
 
-Documentation for the classes can be found on the documentation site here: [about topics](https://thycotic-ps.github.io/thycotic.secretserver/about_topics/)
+Per-type reference (properties, methods, enum values) is published at [Types](https://thycotic-ps.github.io/thycotic.secretserver/types/). The pages are auto-generated from the C# source under `src/Thycotic.SecretServer/`; re-run `scripts/docs/Generate-TypeDocs.ps1` after any class or enum change.
 
 ### Library Build
 

--- a/docs/types/authentication/Session.md
+++ b/docs/types/authentication/Session.md
@@ -1,0 +1,49 @@
+---
+title: Session
+parent: Authentication
+grand_parent: Types
+---
+
+# Session
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Authentication.Session`  
+**Namespace:** `Thycotic.PowerShell.Authentication`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `access_token` | `string` | read/write | — |
+| `AccessToken` | `string` | read/write | — |
+| `ApiUrl` | `string` | read/write | — |
+| `ApiVersion` | `string` | read/write | `"api/v1"` |
+| `expires_in` | `int` | read/write | — |
+| `ExpiresIn` | `int` | read/write | — |
+| `refresh_token` | `string` | read/write | — |
+| `RefreshToken` | `string` | read/write | — |
+| `SecretServer` | `string` | read/write | — |
+| `SecretServerVersion` | `string` | read/write | — |
+| `SkipCertificateCheck` | `bool` | read/write | `false` |
+| `StartTime` | `DateTime` | read/write | — |
+| `Take` | `int` | read/write | `int.MaxValue` |
+| `TimeOfDeath` | `DateTime` | read/write | — |
+| `token_type` | `string` | read/write | — |
+| `TokenType` | `string` | read/write | — |
+| `WindowsAuth` | `string` | readonly | `"winauthwebservices"` |
+
+## Methods
+
+- `[static RestResponse] AccessToken(string SecretServerHost, string Username, string Password, string ProxyServer, int Timeout = 0)`
+- `[bool] CheckTokenTtl(int Value)`
+- `[bool] IsValidSession()`
+- `[bool] IsValidToken()`
+- `[static RestResponse] RefreshToken(string SecretServerHost, string TokenValue, string ProxyServer, int Timeout = 0)`
+- `[bool] SessionExpire()`
+- `[bool] SessionRefresh()`
+
+

--- a/docs/types/authentication/readme.md
+++ b/docs/types/authentication/readme.md
@@ -1,0 +1,11 @@
+---
+title: Authentication
+parent: Types
+has_children: true
+---
+
+# Authentication
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/common/Delete.md
+++ b/docs/types/common/Delete.md
@@ -1,0 +1,25 @@
+---
+title: Delete
+parent: Common
+grand_parent: Types
+---
+
+# Delete
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Common.Delete`  
+**Namespace:** `Thycotic.PowerShell.Common`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `string` | read/write | — |
+| `ObjectType` | `string` | read/write | — |
+| `ResponseCodes` | `string[]` | read/write | — |
+
+

--- a/docs/types/common/RequestStatus.md
+++ b/docs/types/common/RequestStatus.md
@@ -1,0 +1,27 @@
+---
+title: RequestStatus
+parent: Common
+grand_parent: Types
+---
+
+# RequestStatus
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Common.RequestStatus`  
+**Namespace:** `Thycotic.PowerShell.Common`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `IsSuccessful` | `bool` | read/write | — |
+| `ResponseStatus` | `string` | read/write | — |
+| `ResponseUri` | `string` | read/write | — |
+| `StatusCode` | `int` | read/write | — |
+| `StatusDescription` | `string` | read/write | — |
+
+

--- a/docs/types/common/SemanticVersion.md
+++ b/docs/types/common/SemanticVersion.md
@@ -1,0 +1,26 @@
+---
+title: SemanticVersion
+parent: Common
+grand_parent: Types
+---
+
+# SemanticVersion
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Common.SemanticVersion`  
+**Namespace:** `Thycotic.PowerShell.Common`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Build` | `int` | read/write | — |
+| `Major` | `int` | read/write | — |
+| `Minor` | `int` | read/write | — |
+| `Version` | `string` | read/write | — |
+
+

--- a/docs/types/common/Site.md
+++ b/docs/types/common/Site.md
@@ -1,0 +1,25 @@
+---
+title: Site
+parent: Common
+grand_parent: Types
+---
+
+# Site
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Common.Site`  
+**Namespace:** `Thycotic.PowerShell.Common`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `SiteId` | `int` | read/write | — |
+| `SiteName` | `string` | read/write | — |
+
+

--- a/docs/types/common/TestVersion.md
+++ b/docs/types/common/TestVersion.md
@@ -1,0 +1,25 @@
+---
+title: TestVersion
+parent: Common
+grand_parent: Types
+---
+
+# TestVersion
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Common.TestVersion`  
+**Namespace:** `Thycotic.PowerShell.Common`  
+**Inherits / implements:** SemanticVersion  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `IsLatest` | `bool` | read/write | — |
+| `LatestVersion` | `string` | read/write | — |
+
+

--- a/docs/types/common/readme.md
+++ b/docs/types/common/readme.md
@@ -1,0 +1,11 @@
+---
+title: Common
+parent: Types
+has_children: true
+---
+
+# Common
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/configurations/ApplicationLanguage.md
+++ b/docs/types/configurations/ApplicationLanguage.md
@@ -1,0 +1,24 @@
+---
+title: ApplicationLanguage
+parent: Configurations
+grand_parent: Types
+---
+
+# ApplicationLanguage
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.ApplicationLanguage`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `English` | `9` |
+| `French` | `12` |
+| `German` | `7` |
+| `Japanese` | `17` |
+| `Korean` | `18` |
+| `Portuguese` | `22` |
+
+

--- a/docs/types/configurations/ApplicationSettings.md
+++ b/docs/types/configurations/ApplicationSettings.md
@@ -1,0 +1,52 @@
+---
+title: ApplicationSettings
+parent: Configurations
+grand_parent: Types
+---
+
+# ApplicationSettings
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.ApplicationSettings`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AllowSendTelemetry` | `bool` | read/write | — |
+| `AllowSoftwareUpdateChecks` | `bool` | read/write | — |
+| `ApiRefreshTokensEnabled` | `bool` | read/write | — |
+| `ApiSessionTimeoutDays` | `int` | read/write | — |
+| `ApiSessionTimeoutHours` | `int` | read/write | — |
+| `ApiSessionTimeoutMinutes` | `int` | read/write | — |
+| `ApiSessionTimeoutUnlimited` | `bool` | read/write | — |
+| `ConfigurationEarlyAdopterEnabled` | `bool` | read/write | — |
+| `CustomUrl` | `string` | read/write | — |
+| `DisplayDowntimeMessageToAdminsOnly` | `bool` | read/write | — |
+| `EnableCredSsp` | `bool` | read/write | — |
+| `EnableSyslogCefLogging` | `bool` | read/write | — |
+| `EnableWebServices` | `bool` | read/write | — |
+| `MaximumTokenRefreshesAllowed` | `int` | read/write | — |
+| `MaxSecretLogLength` | `int` | read/write | — |
+| `MobileMaxOfflineDays` | `int` | read/write | — |
+| `MobileMaxOfflineHours` | `int` | read/write | — |
+| `obfuscatePersonallyIdentifiableInformation` | `bool` | read/write | — |
+| `piiObfuscationLevel` | `int` | read/write | — |
+| `PreventApplicationFromSleeping` | `bool` | read/write | — |
+| `PreventDirectApiAuthentication` | `bool` | read/write | — |
+| `syslogCefDateTimeFormat` | `string` | read/write | — |
+| `SyslogCefLogSite` | `int` | read/write | — |
+| `SyslogCefPort` | `int` | read/write | — |
+| `SyslogCefProtocol` | `string` | read/write | — |
+| `SyslogCefServer` | `string` | read/write | — |
+| `SyslogCefTimeZone` | `string` | read/write | — |
+| `TmsInstallationPath` | `string` | read/write | — |
+| `WinRmEndpointUrl` | `string` | read/write | — |
+| `WriteSyslogToEventLog` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/Audit.md
+++ b/docs/types/configurations/Audit.md
@@ -1,0 +1,26 @@
+---
+title: Audit
+parent: Configurations
+grand_parent: Types
+---
+
+# Audit
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.Audit`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Action` | `string` | read/write | — |
+| `Date` | `DateTime?` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `Notes` | `string` | read/write | — |
+
+

--- a/docs/types/configurations/AutomaticExport.md
+++ b/docs/types/configurations/AutomaticExport.md
@@ -1,0 +1,32 @@
+---
+title: AutomaticExport
+parent: Configurations
+grand_parent: Types
+---
+
+# AutomaticExport
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.AutomaticExport`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `EnableAutoExport` | `bool` | read/write | — |
+| `ExportChildFolders` | `bool` | read/write | — |
+| `ExportFolderPaths` | `bool` | read/write | — |
+| `ExportPasswordSecretId` | `int` | read/write | — |
+| `ExportPath` | `string` | read/write | — |
+| `ExportTotpSettings` | `bool` | read/write | — |
+| `FolderId` | `int` | read/write | — |
+| `FrequencyDays` | `int` | read/write | — |
+| `LastExported` | `DateTime?` | read/write | — |
+| `UserId` | `int` | read/write | — |
+
+

--- a/docs/types/configurations/AutomaticExportItem.md
+++ b/docs/types/configurations/AutomaticExportItem.md
@@ -1,0 +1,27 @@
+---
+title: AutomaticExportItem
+parent: Configurations
+grand_parent: Types
+---
+
+# AutomaticExportItem
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.AutomaticExportItem`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AutoExportConfigurationId` | `int` | read/write | — |
+| `CanDownload` | `bool` | read/write | — |
+| `Filename` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `StorageDate` | `DateTime?` | read/write | — |
+
+

--- a/docs/types/configurations/Backup.md
+++ b/docs/types/configurations/Backup.md
@@ -1,0 +1,37 @@
+---
+title: Backup
+parent: Configurations
+grand_parent: Types
+---
+
+# Backup
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.Backup`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `BackupDatabasePath` | `string` | read/write | — |
+| `BackupFailureNotification` | `bool` | read/write | — |
+| `BackupPath` | `string` | read/write | — |
+| `BackupStartDateTime` | `DateTime?` | read/write | — |
+| `ConfigurationSqlBackupTimeoutMinutes` | `int` | read/write | — |
+| `CopyOnlyDatabaseBackup` | `bool` | read/write | — |
+| `EnableDatabaseBackup` | `bool` | read/write | — |
+| `EnableScheduledBackup` | `bool` | read/write | — |
+| `EnableTmsBackup` | `bool` | read/write | — |
+| `EnableWebApplicationBackup` | `bool` | read/write | — |
+| `NumberOfBackupsToKeep` | `int` | read/write | — |
+| `RepeatDays` | `int` | read/write | — |
+| `RepeatHours` | `int` | read/write | — |
+| `RepeatMinutes` | `int` | read/write | — |
+| `TmsInstallationPath` | `string` | read/write | — |
+
+

--- a/docs/types/configurations/DbBackupLog.md
+++ b/docs/types/configurations/DbBackupLog.md
@@ -1,0 +1,26 @@
+---
+title: DbBackupLog
+parent: Configurations
+grand_parent: Types
+---
+
+# DbBackupLog
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.DbBackupLog`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `BackupTime` | `DateTime?` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `Notes` | `string` | read/write | — |
+| `Success` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/DomainSelectorOption.md
+++ b/docs/types/configurations/DomainSelectorOption.md
@@ -1,0 +1,21 @@
+---
+title: DomainSelectorOption
+parent: Configurations
+grand_parent: Types
+---
+
+# DomainSelectorOption
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.DomainSelectorOption`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `DomainLabel` | `0` |
+| `ShowDropdown` | `1` |
+| `HideDomain` | `2` |
+
+

--- a/docs/types/configurations/EmailSettings.md
+++ b/docs/types/configurations/EmailSettings.md
@@ -1,0 +1,34 @@
+---
+title: EmailSettings
+parent: Configurations
+grand_parent: Types
+---
+
+# EmailSettings
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.EmailSettings`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `FromEmailAddress` | `string` | read/write | — |
+| `FromEmailName` | `string` | read/write | — |
+| `SendLegacyEmails` | `bool` | read/write | — |
+| `SmtpCheckCertificateRevocation` | `bool` | read/write | — |
+| `SmtpDomain` | `string` | read/write | — |
+| `SmtpPassword` | `string` | read/write | — |
+| `SmtpPort` | `int` | read/write | — |
+| `SmtpServer` | `string` | read/write | — |
+| `SmtpUseCredentials` | `bool` | read/write | — |
+| `SmtpUseImplicitSSL` | `bool` | read/write | — |
+| `SmtpUserName` | `string` | read/write | — |
+| `SmtpUseSSL` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/Folders.md
+++ b/docs/types/configurations/Folders.md
@@ -1,0 +1,28 @@
+---
+title: Folders
+parent: Configurations
+grand_parent: Types
+---
+
+# Folders
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.Folders`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `EnablePersonalFolders` | `bool` | read/write | — |
+| `PersonalFolderName` | `string` | read/write | — |
+| `PersonalFolderNameOption` | `string` | read/write | — |
+| `PersonalFolderWarning` | `string` | read/write | — |
+| `RequireViewFolderPermission` | `bool` | read/write | — |
+| `ShowPersonalFolderWarning` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/General.md
+++ b/docs/types/configurations/General.md
@@ -1,0 +1,33 @@
+---
+title: General
+parent: Configurations
+grand_parent: Types
+---
+
+# General
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.General`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ApplicationSettings` | `ApplicationSettings` | read/write | — |
+| `Email` | `EmailSettings` | read/write | — |
+| `Folders` | `Folders` | read/write | — |
+| `LauncherSettings` | `LauncherSettings` | read/write | — |
+| `LocalUserPasswords` | `LocalUserPasswords` | read/write | — |
+| `PermissionOptions` | `PermissionOptions` | read/write | — |
+| `ProtocolHandlerSettings` | `ProtocolHandlerSettings` | read/write | — |
+| `sessionRecording` | `SessionRecording` | read/write | — |
+| `unlimitedAdmin` | `UnlimitedAdmin` | read/write | — |
+| `UserExperience` | `UserExperience` | read/write | — |
+| `UserInterface` | `UserInterface` | read/write | — |
+
+

--- a/docs/types/configurations/LauncherSettings.md
+++ b/docs/types/configurations/LauncherSettings.md
@@ -1,0 +1,31 @@
+---
+title: LauncherSettings
+parent: Configurations
+grand_parent: Types
+---
+
+# LauncherSettings
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.LauncherSettings`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CheckInSecretOnLastLauncherClose` | `bool` | read/write | — |
+| `CloseLauncherOnCheckInSecret` | `bool` | read/write | — |
+| `EnableDomainDownload` | `bool` | read/write | — |
+| `EnableDomainUpload` | `bool` | read/write | — |
+| `EnableLauncher` | `bool` | read/write | — |
+| `EnableLauncherAutoUpdate` | `bool` | read/write | — |
+| `EnableWebParsing` | `bool` | read/write | — |
+| `LauncherDeploymentType` | `string` | read/write | — |
+| `SendSecretUrlToLauncher` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/LocalUserPasswords.md
+++ b/docs/types/configurations/LocalUserPasswords.md
@@ -1,0 +1,39 @@
+---
+title: LocalUserPasswords
+parent: Configurations
+grand_parent: Types
+---
+
+# LocalUserPasswords
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.LocalUserPasswords`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AllowUsersToResetForgottenPasswords` | `bool` | read/write | — |
+| `EnableLocalUserPasswordExpiration` | `bool` | read/write | — |
+| `EnableMinimumPasswordAge` | `bool` | read/write | — |
+| `EnablePasswordHistory` | `bool` | read/write | — |
+| `LocalUserPasswordExpirationDays` | `int` | read/write | — |
+| `LocalUserPasswordExpirationHours` | `int` | read/write | — |
+| `LocalUserPasswordExpirationMinutes` | `int` | read/write | — |
+| `MinimumPasswordAgeDays` | `int` | read/write | — |
+| `MinimumPasswordAgeHours` | `int` | read/write | — |
+| `MinimumPasswordAgeMinutes` | `int` | read/write | — |
+| `PasswordHistoryItems` | `int` | read/write | — |
+| `passwordHistoryItemsAll` | `bool` | read/write | — |
+| `PasswordMinimumLength` | `int` | read/write | — |
+| `PasswordRequireLowercase` | `bool` | read/write | — |
+| `PasswordRequireNumbers` | `bool` | read/write | — |
+| `PasswordRequireSymbols` | `bool` | read/write | — |
+| `PasswordRequireUppercase` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/Login.md
+++ b/docs/types/configurations/Login.md
@@ -1,0 +1,37 @@
+---
+title: Login
+parent: Configurations
+grand_parent: Types
+---
+
+# Login
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.Login`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AllowAutoComplete` | `bool` | read/write | — |
+| `AllowRememberMe` | `bool` | read/write | — |
+| `CacheADCredentials` | `bool` | read/write | — |
+| `DefaultLoginDomain` | `string` | read/write | — |
+| `EnableDomainSelector` | `DomainSelectorOption` | read/write | — |
+| `EnableLoginFailureCAPTCHA` | `bool` | read/write | — |
+| `MaxConcurrentLoginsPerUser` | `int` | read/write | — |
+| `MaximumLoginFailures` | `int` | read/write | — |
+| `MaxLoginFailuresBeforeCAPTCHA` | `int` | read/write | — |
+| `RememberMeTimeOutMinutes` | `int` | read/write | — |
+| `SshKeyIntegration` | `LoginSshKeyIntegration` | read/write | — |
+| `TwoFactor` | `LoginTwoFactor` | read/write | — |
+| `UserLockoutTimeMinutes` | `int` | read/write | — |
+| `VisualEncryptedKeyboardEnabled` | `bool` | read/write | — |
+| `VisualEncryptedKeyboardRequired` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/LoginDuo.md
+++ b/docs/types/configurations/LoginDuo.md
@@ -1,0 +1,27 @@
+---
+title: LoginDuo
+parent: Configurations
+grand_parent: Types
+---
+
+# LoginDuo
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.LoginDuo`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ApiHostname` | `string` | read/write | — |
+| `Enable` | `bool` | read/write | — |
+| `IntegrationKey` | `string` | read/write | — |
+| `SecretKey` | `string` | read/write | — |
+| `UseRadiusUsername` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/LoginOpenIdConnect.md
+++ b/docs/types/configurations/LoginOpenIdConnect.md
@@ -1,0 +1,30 @@
+---
+title: LoginOpenIdConnect
+parent: Configurations
+grand_parent: Types
+---
+
+# LoginOpenIdConnect
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.LoginOpenIdConnect`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AddNewUsersToThycoticOne` | `bool` | read/write | — |
+| `ClientId` | `string` | read/write | — |
+| `ClientSecret` | `string` | read/write | — |
+| `ClientSecretExists` | `bool` | read/write | — |
+| `Enable` | `bool` | read/write | — |
+| `LogoutUrl` | `string` | read/write | — |
+| `ServerUrl` | `string` | read/write | — |
+| `UseThycoticOneAuthAsDefault` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/LoginRadius.md
+++ b/docs/types/configurations/LoginRadius.md
@@ -1,0 +1,43 @@
+---
+title: LoginRadius
+parent: Configurations
+grand_parent: Types
+---
+
+# LoginRadius
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.LoginRadius`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AttemptSilentAnswer` | `bool` | read/write | — |
+| `AttemptUserPassword` | `bool` | read/write | — |
+| `ClientPortRange` | `string` | read/write | — |
+| `DefaultUsername` | `string` | read/write | — |
+| `DisableNasIpAddressAttribute` | `bool` | read/write | — |
+| `Enable` | `bool` | read/write | — |
+| `EnableFailoverServer` | `bool` | read/write | — |
+| `EnableRadiusNasId` | `bool` | read/write | — |
+| `FailoverServerIP` | `string` | read/write | — |
+| `FailoverServerPort` | `int` | read/write | — |
+| `FailoverSharedSecret` | `string` | read/write | — |
+| `FailoverTimeoutSeconds` | `int` | read/write | — |
+| `LoginExplanation` | `string` | read/write | — |
+| `NasId` | `string` | read/write | — |
+| `Protocol` | `int` | read/write | — |
+| `ServerIP` | `string` | read/write | — |
+| `ServerPort` | `int` | read/write | — |
+| `SharedSecret` | `string` | read/write | — |
+| `SharedSecretSameForAllUsers` | `bool` | read/write | — |
+| `SilentAnswerValue` | `string` | read/write | — |
+| `TimeoutSeconds` | `int` | read/write | — |
+
+

--- a/docs/types/configurations/LoginSshKeyIntegration.md
+++ b/docs/types/configurations/LoginSshKeyIntegration.md
@@ -1,0 +1,28 @@
+---
+title: LoginSshKeyIntegration
+parent: Configurations
+grand_parent: Types
+---
+
+# LoginSshKeyIntegration
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.LoginSshKeyIntegration`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AuthenticationMethod` | `int` | read/write | — |
+| `Enable` | `bool` | read/write | — |
+| `ExpirationInHours` | `int` | read/write | — |
+| `isPublicSshPassphraseRequired` | `bool` | read/write | — |
+| `KeyExpires` | `bool` | read/write | — |
+| `TwoFactorBypass` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/LoginTwoFactor.md
+++ b/docs/types/configurations/LoginTwoFactor.md
@@ -1,0 +1,29 @@
+---
+title: LoginTwoFactor
+parent: Configurations
+grand_parent: Types
+---
+
+# LoginTwoFactor
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.LoginTwoFactor`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AllowTwoFactorRememberMe` | `bool` | read/write | — |
+| `Duo` | `LoginDuo` | read/write | — |
+| `OpenIdConnect` | `LoginOpenIdConnect` | read/write | — |
+| `Radius` | `LoginRadius` | read/write | — |
+| `RequireTwoFactorForWebLogin` | `bool` | read/write | — |
+| `RequireTwoFactorForWebServices` | `bool` | read/write | — |
+| `TwoFactorRememberMeTimeOutDays` | `int` | read/write | — |
+
+

--- a/docs/types/configurations/PermissionOptions.md
+++ b/docs/types/configurations/PermissionOptions.md
@@ -1,0 +1,27 @@
+---
+title: PermissionOptions
+parent: Configurations
+grand_parent: Types
+---
+
+# PermissionOptions
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.PermissionOptions`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AllowDuplicateSecretNames` | `bool` | read/write | — |
+| `AllowViewUserToRetrieveAutoChangeNextPassword` | `bool` | read/write | — |
+| `DefaultSecretPermissions` | `string` | read/write | — |
+| `EnableApprovalFromEmail` | `bool` | read/write | — |
+| `ForceSecretApproval` | `string` | read/write | — |
+
+

--- a/docs/types/configurations/PersonalFolderNameOption.md
+++ b/docs/types/configurations/PersonalFolderNameOption.md
@@ -1,0 +1,20 @@
+---
+title: PersonalFolderNameOption
+parent: Configurations
+grand_parent: Types
+---
+
+# PersonalFolderNameOption
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.PersonalFolderNameOption`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `DisplayName` | _(default)_ |
+| `UsernameAndDomain` | _(default)_ |
+
+

--- a/docs/types/configurations/ProtocolHandlerSettings.md
+++ b/docs/types/configurations/ProtocolHandlerSettings.md
@@ -1,0 +1,25 @@
+---
+title: ProtocolHandlerSettings
+parent: Configurations
+grand_parent: Types
+---
+
+# ProtocolHandlerSettings
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.ProtocolHandlerSettings`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ProtocolHandlerInstallTimeAllowedDomains` | `string` | read/write | — |
+| `ProtocolHandlerInstallTimeDisableAutoUpdate` | `bool` | read/write | — |
+| `ProtocolHandlerInstallTimeSettingsEnabled` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/Rpc.md
+++ b/docs/types/configurations/Rpc.md
@@ -1,0 +1,29 @@
+---
+title: Rpc
+parent: Configurations
+grand_parent: Types
+---
+
+# Rpc
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.Rpc`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CheckOutIntervalDays` | `int` | read/write | — |
+| `CheckOutIntervalHours` | `int` | read/write | — |
+| `CheckOutIntervalMinutes` | `int` | read/write | — |
+| `DaysToKeepLogs` | `int` | read/write | — |
+| `EnableHeartbeat` | `bool` | read/write | — |
+| `EnablePasswordChangeOnCheckIn` | `bool` | read/write | — |
+| `EnableRpc` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/Saml.md
+++ b/docs/types/configurations/Saml.md
@@ -1,0 +1,30 @@
+---
+title: Saml
+parent: Configurations
+grand_parent: Types
+---
+
+# Saml
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.Saml`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Enabled` | `bool` | read/write | — |
+| `EnableLegacySlo` | `bool` | read/write | — |
+| `IdentityProviders` | `SamlProvider[]` | read/write | — |
+| `LegacyUsernameAttribute` | `string` | read/write | — |
+| `ServiceProviderCertificate` | `string` | read/write | — |
+| `ServiceProviderCertificatePassword` | `string` | read/write | — |
+| `ServiceProviderName` | `string` | read/write | — |
+| `UseLegacy` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/SamlProvider.md
+++ b/docs/types/configurations/SamlProvider.md
@@ -1,0 +1,59 @@
+---
+title: SamlProvider
+parent: Configurations
+grand_parent: Types
+---
+
+# SamlProvider
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.SamlProvider`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `AuthnContext` | `string` | read/write | — |
+| `ClockSkew` | `int` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `DisableAssertionReplayCheck` | `bool` | read/write | — |
+| `DisableAudienceRestrictionCheck` | `bool` | read/write | — |
+| `DisableAuthnContextCheck` | `bool` | read/write | — |
+| `DisableDestinationCheck` | `bool` | read/write | — |
+| `DisableInboundLogout` | `bool` | read/write | — |
+| `DisableInResponseToCheck` | `bool` | read/write | — |
+| `DisablePendingLogoutCheck` | `bool` | read/write | — |
+| `DisableRecipientCheck` | `bool` | read/write | — |
+| `DisableTimePeriodCheck` | `bool` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `DomainAttribute` | `string` | read/write | — |
+| `EnableDetailedLog` | `bool` | read/write | — |
+| `EnableSLO` | `bool` | read/write | — |
+| `ForceAuthentication` | `bool` | read/write | — |
+| `IdentityProviderId` | `int` | read/write | — |
+| `LogoutRequestLifeTime` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `OverridePendingAuthnRequest` | `bool` | read/write | — |
+| `PublicCertificate` | `string` | read/write | — |
+| `SignAuthnRequest` | `bool` | read/write | — |
+| `SignLogoutRequest` | `bool` | read/write | — |
+| `SignLogoutResponse` | `bool` | read/write | — |
+| `SingleLogoutServiceResponseUrl` | `string` | read/write | — |
+| `SingleLogoutServiceUrl` | `string` | read/write | — |
+| `SsoServiceBinding` | `int` | read/write | — |
+| `SsoServiceUrl` | `string` | read/write | — |
+| `UsernameAttribute` | `string` | read/write | — |
+| `WantAssertionEncrypted` | `bool` | read/write | — |
+| `WantAssertionOrResponseSigned` | `bool` | read/write | — |
+| `WantAssertionSigned` | `bool` | read/write | — |
+| `WantLogoutRequestSigned` | `bool` | read/write | — |
+| `WantLogoutResponseSigned` | `bool` | read/write | — |
+| `WantSAMLResponseSigned` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/SearchIndexMode.md
+++ b/docs/types/configurations/SearchIndexMode.md
@@ -1,0 +1,20 @@
+---
+title: SearchIndexMode
+parent: Configurations
+grand_parent: Types
+---
+
+# SearchIndexMode
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SearchIndexMode`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Standard` | _(default)_ |
+| `Extended` | _(default)_ |
+
+

--- a/docs/types/configurations/SearchIndexStatus.md
+++ b/docs/types/configurations/SearchIndexStatus.md
@@ -1,0 +1,21 @@
+---
+title: SearchIndexStatus
+parent: Configurations
+grand_parent: Types
+---
+
+# SearchIndexStatus
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SearchIndexStatus`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `NotStarted` | _(default)_ |
+| `Idle` | _(default)_ |
+| `Indexing` | _(default)_ |
+
+

--- a/docs/types/configurations/SearchIndexer.md
+++ b/docs/types/configurations/SearchIndexer.md
@@ -1,0 +1,30 @@
+---
+title: SearchIndexer
+parent: Configurations
+grand_parent: Types
+---
+
+# SearchIndexer
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.SearchIndexer`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DaysToKeepLogs` | `int` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `IndexingSeparators` | `string[]` | read/write | — |
+| `IndexMode` | `SearchIndexMode` | read/write | — |
+| `IndexPercentComplete` | `float` | read/write | — |
+| `LastIndexDate` | `DateTime?` | read/write | — |
+| `LogAvailable` | `bool` | read/write | — |
+| `Status` | `SearchIndexStatus` | read/write | — |
+
+

--- a/docs/types/configurations/SecretApprovalType.md
+++ b/docs/types/configurations/SecretApprovalType.md
@@ -1,0 +1,20 @@
+---
+title: SecretApprovalType
+parent: Configurations
+grand_parent: Types
+---
+
+# SecretApprovalType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretApprovalType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `RequireApprovalForEditors` | _(default)_ |
+| `RequireApprovalForOwnersAndEditors` | _(default)_ |
+
+

--- a/docs/types/configurations/SecretPermissionType.md
+++ b/docs/types/configurations/SecretPermissionType.md
@@ -1,0 +1,21 @@
+---
+title: SecretPermissionType
+parent: Configurations
+grand_parent: Types
+---
+
+# SecretPermissionType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretPermissionType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `InheritsPermissions` | _(default)_ |
+| `CopyFromFolder` | _(default)_ |
+| `OnlyAllowCreator` | _(default)_ |
+
+

--- a/docs/types/configurations/Security.md
+++ b/docs/types/configurations/Security.md
@@ -1,0 +1,46 @@
+---
+title: Security
+parent: Configurations
+grand_parent: Types
+---
+
+# Security
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.Security`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `allowFilesWithoutExtension` | `bool` | read/write | — |
+| `AllowWebServiceHttpGet` | `bool` | read/write | — |
+| `AuditTlsErrors` | `bool` | read/write | — |
+| `AuditTlsErrorsDebug` | `bool` | read/write | — |
+| `CertificateChainPolicyOptions` | `string` | read/write | — |
+| `ClientCertificateIds` | `string` | read/write | — |
+| `DatabaseIntegrityMonitoringSymmetricKey` | `string` | read/write | — |
+| `enableApplicationHardening` | `bool` | read/write | — |
+| `EnableDatabaseIntegrityMonitoring` | `bool` | read/write | — |
+| `EnableFileRestrictions` | `bool` | read/write | — |
+| `EnableFrameBlocking` | `bool` | read/write | — |
+| `EnableHSTS` | `bool` | read/write | — |
+| `enableSecretErase` | `bool` | read/write | — |
+| `FileExtensionRestrictions` | `string` | read/write | — |
+| `FipsEnabled` | `bool` | read/write | — |
+| `ForceHttps` | `bool` | read/write | — |
+| `HideVersionNumber` | `bool` | read/write | — |
+| `HstsMaxAge` | `int` | read/write | — |
+| `ignoreCertificateRevocationFailures` | `bool` | read/write | — |
+| `MaximumFileSizeBytes` | `int` | read/write | — |
+| `MaximumFileSizeSupported` | `bool` | read/write | — |
+| `multifactorAuthenticationProfile` | `string` | read/write | — |
+| `secretEraseWorkflow` | `int` | read/write | — |
+| `WebPasswordFillerRequiresFullDomainMatch` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/SessionRecording.md
+++ b/docs/types/configurations/SessionRecording.md
@@ -1,0 +1,44 @@
+---
+title: SessionRecording
+parent: Configurations
+grand_parent: Types
+---
+
+# SessionRecording
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.SessionRecording`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `archiveLocationBySite` | `bool` | read/write | — |
+| `archivePath` | `string` | read/write | — |
+| `archivePathMappings` | `SessionRecordingArchivePathMappings[]` | read/write | — |
+| `daysUntilArchive` | `int` | read/write | — |
+| `daysUntilDelete` | `int` | read/write | — |
+| `enableArchive` | `bool` | read/write | — |
+| `enableDelete` | `bool` | read/write | — |
+| `enableHardwareAcceleration` | `bool` | read/write | — |
+| `enableInactivityTimeout` | `bool` | read/write | — |
+| `enableOnDemandVideoProcessing` | `bool` | read/write | — |
+| `enableSessionRecording` | `bool` | read/write | — |
+| `encryptArchive` | `bool` | read/write | — |
+| `hideRecordingIndicator` | `bool` | read/write | — |
+| `inactivityTimeoutMinutes` | `int` | read/write | — |
+| `maxSessionLength` | `int` | read/write | — |
+| `rdpProxyRecordKeyStrokes` | `bool` | read/write | — |
+| `rdpProxyRecordVideo` | `bool` | read/write | — |
+| `sshProxyRecordKeyStrokes` | `bool` | read/write | — |
+| `sshProxyRecordVideo` | `bool` | read/write | — |
+| `storeInDatabase` | `bool` | read/write | — |
+| `useTemporaryArchives` | `bool` | read/write | — |
+| `videoCodecId` | `int` | read/write | — |
+
+

--- a/docs/types/configurations/SessionRecordingArchivePathMappings.md
+++ b/docs/types/configurations/SessionRecordingArchivePathMappings.md
@@ -1,0 +1,25 @@
+---
+title: SessionRecordingArchivePathMappings
+parent: Configurations
+grand_parent: Types
+---
+
+# SessionRecordingArchivePathMappings
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.SessionRecordingArchivePathMappings`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Path` | `string` | read/write | — |
+| `siteId` | `int` | read/write | — |
+| `SiteName` | `string` | read/write | — |
+
+

--- a/docs/types/configurations/SiteConnector.md
+++ b/docs/types/configurations/SiteConnector.md
@@ -1,0 +1,25 @@
+---
+title: SiteConnector
+parent: Configurations
+grand_parent: Types
+---
+
+# SiteConnector
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.SiteConnector`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `SiteConnectorId` | `int` | read/write | — |
+| `SiteConnectorName` | `string` | read/write | — |
+
+

--- a/docs/types/configurations/UnlimitedAdmin.md
+++ b/docs/types/configurations/UnlimitedAdmin.md
@@ -1,0 +1,23 @@
+---
+title: UnlimitedAdmin
+parent: Configurations
+grand_parent: Types
+---
+
+# UnlimitedAdmin
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.UnlimitedAdmin`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Enabled` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/UserExperience.md
+++ b/docs/types/configurations/UserExperience.md
@@ -1,0 +1,38 @@
+---
+title: UserExperience
+parent: Configurations
+grand_parent: Types
+---
+
+# UserExperience
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.UserExperience`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ApplicationLanguage` | `int` | read/write | — |
+| `checkoutNotificationThreshold` | `int` | read/write | — |
+| `DefaultDateFormat` | `int` | read/write | — |
+| `DefaultNewUserRoleId` | `int` | read/write | — |
+| `DefaultTimeFormat` | `int` | read/write | — |
+| `enableSecretCheckOutExtension` | `bool` | read/write | — |
+| `ForceInactivityTimeout` | `bool` | read/write | — |
+| `ForceInactivityTimeoutMinutes` | `int` | read/write | — |
+| `maxCheckOutExtensionInMinutes` | `int` | read/write | — |
+| `RequireFolderForSecret` | `bool` | read/write | — |
+| `SearchDelayMs` | `int` | read/write | — |
+| `SecretPasswordHistoryRestrictionAll` | `bool` | read/write | — |
+| `SecretPasswordHistoryRestrictionCount` | `int` | read/write | — |
+| `SecretViewIntervalMinutes` | `int` | read/write | — |
+| `ServerTimeZoneId` | `string` | read/write | — |
+| `UiInactivitySleepMinutes` | `int` | read/write | — |
+
+

--- a/docs/types/configurations/UserInterface.md
+++ b/docs/types/configurations/UserInterface.md
@@ -1,0 +1,38 @@
+---
+title: UserInterface
+parent: Configurations
+grand_parent: Types
+---
+
+# UserInterface
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Configuration.UserInterface`  
+**Namespace:** `Thycotic.PowerShell.Configuration`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AllowUserToSelectTheme` | `bool` | read/write | — |
+| `CustomBannerStyle` | `string` | read/write | — |
+| `CustomBannerText` | `string` | read/write | — |
+| `CustomBannerViewLink` | `string` | read/write | — |
+| `CustomBannerViewLinkText` | `string` | read/write | — |
+| `CustomLogoCollapsed` | `string` | read/write | — |
+| `CustomLogoCollapsedDark` | `string` | read/write | — |
+| `CustomLogoFullSize` | `string` | read/write | — |
+| `CustomLogoFullSizeDark` | `string` | read/write | — |
+| `CustomLogoLogin` | `string` | read/write | — |
+| `CustomLogoLoginDark` | `string` | read/write | — |
+| `DefaultClassicTheme` | `string` | read/write | — |
+| `disableLegacyUi` | `bool` | read/write | — |
+| `isCustomBannerDismissable` | `bool` | read/write | — |
+| `NewUiDefault` | `bool` | read/write | — |
+| `showCustomBanner` | `bool` | read/write | — |
+
+

--- a/docs/types/configurations/readme.md
+++ b/docs/types/configurations/readme.md
@@ -1,0 +1,11 @@
+---
+title: Configurations
+parent: Types
+has_children: true
+---
+
+# Configurations
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/diagnostics/BackgroundProcess.md
+++ b/docs/types/diagnostics/BackgroundProcess.md
@@ -1,0 +1,28 @@
+---
+title: BackgroundProcess
+parent: Diagnostics
+grand_parent: Types
+---
+
+# BackgroundProcess
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Diagnostics.BackgroundProcess`  
+**Namespace:** `Thycotic.PowerShell.Diagnostics`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ApplicationName` | `string` | read/write | — |
+| `Hostname` | `string` | read/write | — |
+| `IdentityName` | `string` | read/write | — |
+| `LastActivity` | `DateTime?` | read/write | — |
+| `ManagedThreadId` | `int` | read/write | — |
+| `ThreadName` | `string` | read/write | — |
+
+

--- a/docs/types/diagnostics/ConnectivityReport.md
+++ b/docs/types/diagnostics/ConnectivityReport.md
@@ -1,0 +1,24 @@
+---
+title: ConnectivityReport
+parent: Diagnostics
+grand_parent: Types
+---
+
+# ConnectivityReport
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Diagnostics.ConnectivityReport`  
+**Namespace:** `Thycotic.PowerShell.Diagnostics`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Address` | `string` | read/write | — |
+| `IsSuccess` | `bool` | read/write | — |
+
+

--- a/docs/types/diagnostics/Diagnostic.md
+++ b/docs/types/diagnostics/Diagnostic.md
@@ -1,0 +1,57 @@
+---
+title: Diagnostic
+parent: Diagnostics
+grand_parent: Types
+---
+
+# Diagnostic
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Diagnostics.Diagnostic`  
+**Namespace:** `Thycotic.PowerShell.Diagnostics`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ActiveDirectorySynchronizationThreadStatus` | `string` | read/write | — |
+| `BackboneClass` | `string` | read/write | — |
+| `BackboneType` | `string` | read/write | — |
+| `HsmCacheMapSize` | `string` | read/write | — |
+| `HsmTiming` | `string` | read/write | — |
+| `IsDomainController` | `string` | read/write | — |
+| `LastUpgrade` | `string` | read/write | — |
+| `LdapProvider` | `string` | read/write | — |
+| `MaxDegreeOfParallelism` | `string` | read/write | — |
+| `NetFxVersion` | `string` | read/write | — |
+| `OperatingSystem` | `string` | read/write | — |
+| `OperatingSystemArchitecture` | `string` | read/write | — |
+| `PhysicalMemory` | `string` | read/write | — |
+| `ProductVersion` | `string` | read/write | — |
+| `ProxyConfiguration` | `string` | read/write | — |
+| `ReadOnlyMode` | `string` | read/write | — |
+| `SearchIndexerThreadStatus` | `string` | read/write | — |
+| `SecretServerUrl` | `string` | read/write | — |
+| `ServerName` | `string` | read/write | — |
+| `ServerTime` | `string` | read/write | — |
+| `ServerTimeZone` | `string` | read/write | — |
+| `SqlDatabaseName` | `string` | read/write | — |
+| `SqlIsDatabaseReplicated` | `string` | read/write | — |
+| `SqlServerCollation` | `string` | read/write | — |
+| `SqlServerConnectionString` | `string` | read/write | — |
+| `SqlServerEdition` | `string` | read/write | — |
+| `SqlServerIsPublished` | `string` | read/write | — |
+| `SqlServerIsReplicationRunning` | `string` | read/write | — |
+| `SqlServerIsSubscribed` | `string` | read/write | — |
+| `SqlServerName` | `string` | read/write | — |
+| `SqlServerTime` | `string` | read/write | — |
+| `SqlServerVersion` | `string` | read/write | — |
+| `UpgradeAvailable` | `string` | read/write | — |
+| `UpgradeInProgress` | `string` | read/write | — |
+| `UpTime` | `string` | read/write | — |
+
+

--- a/docs/types/diagnostics/SystemLog.md
+++ b/docs/types/diagnostics/SystemLog.md
@@ -1,0 +1,27 @@
+---
+title: SystemLog
+parent: Diagnostics
+grand_parent: Types
+---
+
+# SystemLog
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Diagnostics.SystemLog`  
+**Namespace:** `Thycotic.PowerShell.Diagnostics`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CorrelationId` | `string` | read/write | — |
+| `DateRecorded` | `DateTime?` | read/write | — |
+| `LogLevel` | `LogLevel` | read/write | — |
+| `LogMessage` | `string` | read/write | — |
+| `MachineName` | `string` | read/write | — |
+
+

--- a/docs/types/diagnostics/readme.md
+++ b/docs/types/diagnostics/readme.md
@@ -1,0 +1,11 @@
+---
+title: Diagnostics
+parent: Types
+has_children: true
+---
+
+# Diagnostics
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/directory-services/Domain.md
+++ b/docs/types/directory-services/Domain.md
@@ -1,0 +1,30 @@
+---
+title: Domain
+parent: Directory Services
+grand_parent: Types
+---
+
+# Domain
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DirectoryServices.Domain`  
+**Namespace:** `Thycotic.PowerShell.DirectoryServices`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `DomainId` | `int` | read/write | — |
+| `DomainName` | `string` | read/write | — |
+| `FriendlyName` | `string` | read/write | — |
+| `MultifactorAuthenticationProvider` | `MfaProviderType` | read/write | — |
+| `SiteId` | `int` | read/write | — |
+| `SynchronizationSecretId` | `int` | read/write | — |
+| `UseSecureLdap` | `bool` | read/write | — |
+
+

--- a/docs/types/directory-services/DomainSummary.md
+++ b/docs/types/directory-services/DomainSummary.md
@@ -1,0 +1,29 @@
+---
+title: DomainSummary
+parent: Directory Services
+grand_parent: Types
+---
+
+# DomainSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DirectoryServices.DomainSummary`  
+**Namespace:** `Thycotic.PowerShell.DirectoryServices`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `DomainId` | `int` | read/write | — |
+| `DomainName` | `string` | read/write | — |
+| `DomainType` | `string` | read/write | — |
+| `FriendlyName` | `string` | read/write | — |
+| `RequireRadiusAuthentication` | `bool` | read/write | — |
+| `UseSecureLdap` | `bool` | read/write | — |
+
+

--- a/docs/types/directory-services/DomainSyncStatus.md
+++ b/docs/types/directory-services/DomainSyncStatus.md
@@ -1,0 +1,29 @@
+---
+title: DomainSyncStatus
+parent: Directory Services
+grand_parent: Types
+---
+
+# DomainSyncStatus
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DirectoryServices.DomainSyncStatus`  
+**Namespace:** `Thycotic.PowerShell.DirectoryServices`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DisabledUsers` | `int` | read/write | — |
+| `DomainId` | `int` | read/write | — |
+| `DomainUsersUpdatedSinceLastSynchronization` | `int` | read/write | — |
+| `NewUsersCreated` | `int` | read/write | — |
+| `NewUsersCreatedAsDisabled` | `int` | read/write | — |
+| `UsersRemovedFromGroups` | `int` | read/write | — |
+| `UsersWithGroupMembershipChanges` | `int` | read/write | — |
+
+

--- a/docs/types/directory-services/Group.md
+++ b/docs/types/directory-services/Group.md
@@ -1,0 +1,24 @@
+---
+title: Group
+parent: Directory Services
+grand_parent: Types
+---
+
+# Group
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DirectoryServices.Group`  
+**Namespace:** `Thycotic.PowerShell.DirectoryServices`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DsGuid` | `Guid` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/directory-services/GroupMember.md
+++ b/docs/types/directory-services/GroupMember.md
@@ -1,0 +1,23 @@
+---
+title: GroupMember
+parent: Directory Services
+grand_parent: Types
+---
+
+# GroupMember
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DirectoryServices.GroupMember`  
+**Namespace:** `Thycotic.PowerShell.DirectoryServices`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DisplayName` | `string` | read/write | — |
+
+

--- a/docs/types/directory-services/LdapAuthType.md
+++ b/docs/types/directory-services/LdapAuthType.md
@@ -1,0 +1,21 @@
+---
+title: LdapAuthType
+parent: Directory Services
+grand_parent: Types
+---
+
+# LdapAuthType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.LdapAuthType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Basic` | _(default)_ |
+| `Anonymous` | _(default)_ |
+| `Kerberos` | _(default)_ |
+
+

--- a/docs/types/directory-services/MfaProviderType.md
+++ b/docs/types/directory-services/MfaProviderType.md
@@ -1,0 +1,24 @@
+---
+title: MfaProviderType
+parent: Directory Services
+grand_parent: Types
+---
+
+# MfaProviderType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.MfaProviderType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `None` | _(default)_ |
+| `Radius` | _(default)_ |
+| `TOTPAuthenticator` | _(default)_ |
+| `Duo` | _(default)_ |
+| `Fido2` | _(default)_ |
+| `Email` | _(default)_ |
+
+

--- a/docs/types/directory-services/SyncStatus.md
+++ b/docs/types/directory-services/SyncStatus.md
@@ -1,0 +1,28 @@
+---
+title: SyncStatus
+parent: Directory Services
+grand_parent: Types
+---
+
+# SyncStatus
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DirectoryServices.SyncStatus`  
+**Namespace:** `Thycotic.PowerShell.DirectoryServices`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DomainStatus` | `DomainSyncStatus[]` | read/write | — |
+| `EndDateTime` | `DateTime?` | read/write | — |
+| `ErrorCount` | `int` | read/write | — |
+| `EstimatedPercentComplete` | `int` | read/write | — |
+| `NextSynchronizationDateTime` | `DateTime?` | read/write | — |
+| `StartDateTime` | `DateTime?` | read/write | — |
+
+

--- a/docs/types/directory-services/UserAuthType.md
+++ b/docs/types/directory-services/UserAuthType.md
@@ -1,0 +1,21 @@
+---
+title: UserAuthType
+parent: Directory Services
+grand_parent: Types
+---
+
+# UserAuthType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.UserAuthType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Basic` | _(default)_ |
+| `NoAuthentication` | _(default)_ |
+| `Kerberos` | _(default)_ |
+
+

--- a/docs/types/directory-services/readme.md
+++ b/docs/types/directory-services/readme.md
@@ -1,0 +1,11 @@
+---
+title: Directory Services
+parent: Types
+has_children: true
+---
+
+# Directory Services
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/discovery/DiscoveryActionType.md
+++ b/docs/types/discovery/DiscoveryActionType.md
@@ -1,0 +1,24 @@
+---
+title: DiscoveryActionType
+parent: Discovery
+grand_parent: Types
+---
+
+# DiscoveryActionType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.DiscoveryActionType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `CreateDiscoverySource` | _(default)_ |
+| `EditConfiguration` | _(default)_ |
+| `EditDiscoverySource` | _(default)_ |
+| `RunComputerScan` | _(default)_ |
+| `RunDiscovery` | _(default)_ |
+| `ViewScanners` | _(default)_ |
+
+

--- a/docs/types/discovery/Status.md
+++ b/docs/types/discovery/Status.md
@@ -1,0 +1,33 @@
+---
+title: Status
+parent: Discovery
+grand_parent: Types
+---
+
+# Status
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Discovery.Status`  
+**Namespace:** `Thycotic.PowerShell.Discovery`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Actions` | `DiscoveryActionType[]` | read/write | — |
+| `ComputerScanEndDateTime` | `DateTime?` | read/write | — |
+| `ComputerScanStartDateTime` | `DateTime?` | read/write | — |
+| `DiscoveryEndDateTime` | `DateTime?` | read/write | — |
+| `DiscoverySourceCount` | `int` | read/write | — |
+| `DiscoveryStartDateTime` | `DateTime?` | read/write | — |
+| `IsComputerScanRunning` | `bool` | read/write | — |
+| `IsDiscoveryEnabled` | `bool` | read/write | — |
+| `IsDiscoveryRunning` | `bool` | read/write | — |
+| `NextComputerScanStart` | `DateTime?` | read/write | — |
+| `NextDiscoveryStart` | `DateTime?` | read/write | — |
+
+

--- a/docs/types/discovery/readme.md
+++ b/docs/types/discovery/readme.md
@@ -1,0 +1,11 @@
+---
+title: Discovery
+parent: Types
+has_children: true
+---
+
+# Discovery
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/distributed-engines/CloudAccessResult.md
+++ b/docs/types/distributed-engines/CloudAccessResult.md
@@ -1,0 +1,26 @@
+---
+title: CloudAccessResult
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# CloudAccessResult
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.CloudAccessResult`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `HostAddress` | `string` | read/write | — |
+| `ItemName` | `string` | read/write | — |
+| `Port` | `int` | read/write | — |
+| `Status` | `string` | read/write | — |
+
+

--- a/docs/types/distributed-engines/Configuration.md
+++ b/docs/types/distributed-engines/Configuration.md
@@ -1,0 +1,38 @@
+---
+title: Configuration
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# Configuration
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.Configuration`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `autoUpdateEnginesVersion` | `bool` | read/write | — |
+| `AzureServiceBusTransportType` | `EngineAzServiceBusType` | read/write | — |
+| `CallbackPort` | `int` | read/write | — |
+| `CallbackUrl` | `string` | read/write | — |
+| `DefaultCallbackIntervalSeconds` | `int` | read/write | — |
+| `EnableDistributedEngines` | `bool` | read/write | — |
+| `engineVersionUpdateAvailable` | `bool` | read/write | — |
+| `latestDistributedEnginesVersion` | `string` | read/write | — |
+| `minimumRequiredDistributedEnginesVersion` | `string` | read/write | — |
+| `Protocol` | `EngineProtocol` | read/write | — |
+| `ResponseBusSiteConnectorId` | `int` | read/write | — |
+| `SecretHeartbeatMessageMinutesToLive` | `int` | read/write | — |
+| `SecretHeartbeatMessageRetryMinutes` | `int` | read/write | — |
+| `SecretPasswordChangeMessageMinutesToLive` | `int` | read/write | — |
+| `SecretPasswordChangeMessageRetryMinutes` | `int` | read/write | — |
+| `updateEnginesBannerMessage` | `string` | read/write | — |
+
+

--- a/docs/types/distributed-engines/EngineActivation.md
+++ b/docs/types/distributed-engines/EngineActivation.md
@@ -1,0 +1,26 @@
+---
+title: EngineActivation
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# EngineActivation
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.EngineActivation`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `EngineId` | `int` | read/write | — |
+| `EngineName` | `string` | read/write | — |
+| `Error` | `string` | read/write | — |
+| `IsSuccessful` | `bool` | read/write | — |
+
+

--- a/docs/types/distributed-engines/EngineActivationStatus.md
+++ b/docs/types/distributed-engines/EngineActivationStatus.md
@@ -1,0 +1,22 @@
+---
+title: EngineActivationStatus
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# EngineActivationStatus
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.EngineActivationStatus`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Pending` | _(default)_ |
+| `Activated` | _(default)_ |
+| `Inactive` | _(default)_ |
+| `Deleted` | _(default)_ |
+
+

--- a/docs/types/distributed-engines/EngineAzServiceBusType.md
+++ b/docs/types/distributed-engines/EngineAzServiceBusType.md
@@ -1,0 +1,20 @@
+---
+title: EngineAzServiceBusType
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# EngineAzServiceBusType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.EngineAzServiceBusType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Amqp` | _(default)_ |
+| `AmqpWebSockets` | _(default)_ |
+
+

--- a/docs/types/distributed-engines/EngineConnectionStatus.md
+++ b/docs/types/distributed-engines/EngineConnectionStatus.md
@@ -1,0 +1,22 @@
+---
+title: EngineConnectionStatus
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# EngineConnectionStatus
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.EngineConnectionStatus`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Offline` | _(default)_ |
+| `Online` | _(default)_ |
+| `Invalid` | _(default)_ |
+| `OldVersion` | _(default)_ |
+
+

--- a/docs/types/distributed-engines/EngineProtocol.md
+++ b/docs/types/distributed-engines/EngineProtocol.md
@@ -1,0 +1,21 @@
+---
+title: EngineProtocol
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# EngineProtocol
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.EngineProtocol`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Http` | _(default)_ |
+| `Https` | _(default)_ |
+| `Tcp` | _(default)_ |
+
+

--- a/docs/types/distributed-engines/EngineStatusType.md
+++ b/docs/types/distributed-engines/EngineStatusType.md
@@ -1,0 +1,22 @@
+---
+title: EngineStatusType
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# EngineStatusType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.EngineStatusType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Activate` | _(default)_ |
+| `Deactivate` | _(default)_ |
+| `RemoveFromSite` | _(default)_ |
+| `Delete` | _(default)_ |
+
+

--- a/docs/types/distributed-engines/EngineSummary.md
+++ b/docs/types/distributed-engines/EngineSummary.md
@@ -1,0 +1,37 @@
+---
+title: EngineSummary
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# EngineSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.EngineSummary`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ActivationStatus` | `EngineActivationStatus` | read/write | — |
+| `BindAddress` | `string` | read/write | — |
+| `canCancelUpdateVersion` | `bool` | read/write | — |
+| `canUpdateVersion` | `bool` | read/write | — |
+| `ConnectionStatus` | `EngineConnectionStatus` | read/write | — |
+| `currentVersion` | `string` | read/write | — |
+| `EngineId` | `int` | read/write | — |
+| `FriendlyName` | `string` | read/write | — |
+| `Hostname` | `string` | read/write | — |
+| `IsBlockedByNet48` | `bool` | read/write | — |
+| `LastConnected` | `DateTime?` | read/write | — |
+| `latestVersion` | `string` | read/write | — |
+| `pendingUpdate` | `bool` | read/write | — |
+| `timeMismatch` | `bool` | read/write | — |
+| `timeMismatchSeconds` | `int` | read/write | — |
+
+

--- a/docs/types/distributed-engines/ServerCapabilities.md
+++ b/docs/types/distributed-engines/ServerCapabilities.md
@@ -1,0 +1,36 @@
+---
+title: ServerCapabilities
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# ServerCapabilities
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.ServerCapabilities`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Architecture` | `string` | read/write | — |
+| `ComputerName` | `string` | read/write | — |
+| `DotNetRelease` | `int` | read/write | — |
+| `DotNetVersion` | `string` | read/write | — |
+| `InstallationPath` | `string` | read/write | — |
+| `LastModifiedDate` | `DateTime?` | read/write | — |
+| `OperatingSystemPlatform` | `string` | read/write | — |
+| `OperatingSystemServicePack` | `string` | read/write | — |
+| `OperatingSystemVersion` | `string` | read/write | — |
+| `PowerShellVersion` | `string` | read/write | — |
+| `ProcessorCount` | `int` | read/write | — |
+| `ServiceAccountCanRestartService` | `bool` | read/write | — |
+| `ServiceAccountName` | `string` | read/write | — |
+| `SystemDirectory` | `string` | read/write | — |
+
+

--- a/docs/types/distributed-engines/Site.md
+++ b/docs/types/distributed-engines/Site.md
@@ -1,0 +1,40 @@
+---
+title: Site
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# Site
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.Site`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `EnableCredSspForWinRm` | `bool` | read/write | — |
+| `EnableRdpProxy` | `bool` | read/write | — |
+| `EnableSshProxy` | `bool` | read/write | — |
+| `HeartbeatInterval` | `int` | read/write | — |
+| `jumpBoxAvailablePortRange` | `string` | read/write | — |
+| `PowerShellSecretId` | `int` | read/write | — |
+| `ProcessingLocation` | `SiteProcessLocationType` | read/write | — |
+| `RdpProxyPort` | `int` | read/write | — |
+| `RdpProxyPortInherited` | `bool` | read/write | — |
+| `SecretCount` | `int` | read/write | — |
+| `SiteConnectorId` | `int` | read/write | — |
+| `SiteId` | `int` | read/write | — |
+| `SiteName` | `string` | read/write | — |
+| `SshProxyPort` | `int` | read/write | — |
+| `SshProxyPortInherited` | `bool` | read/write | — |
+| `SystemSite` | `bool` | read/write | — |
+| `WinRmEndPointUrl` | `string` | read/write | — |
+
+

--- a/docs/types/distributed-engines/SiteConnector.md
+++ b/docs/types/distributed-engines/SiteConnector.md
@@ -1,0 +1,33 @@
+---
+title: SiteConnector
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# SiteConnector
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.SiteConnector`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `Hostname` | `string` | read/write | — |
+| `Port` | `int` | read/write | — |
+| `QueueType` | `SiteConnectorQueueType` | read/write | — |
+| `SharedAccessKeyName` | `string` | read/write | — |
+| `SharedAccessKeyValue` | `string` | read/write | — |
+| `SiteConnectorId` | `int` | read/write | — |
+| `SiteConnectorName` | `string` | read/write | — |
+| `SslCertificateThumbprint` | `string` | read/write | — |
+| `UseSsl` | `bool` | read/write | — |
+| `Validated` | `bool` | read/write | — |
+
+

--- a/docs/types/distributed-engines/SiteConnectorQueueType.md
+++ b/docs/types/distributed-engines/SiteConnectorQueueType.md
@@ -1,0 +1,21 @@
+---
+title: SiteConnectorQueueType
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# SiteConnectorQueueType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SiteConnectorQueueType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `MemoryMq` | _(default)_ |
+| `RabbitMq` | _(default)_ |
+| `AzureServiceBus` | _(default)_ |
+
+

--- a/docs/types/distributed-engines/SiteConnectorSummary.md
+++ b/docs/types/distributed-engines/SiteConnectorSummary.md
@@ -1,0 +1,29 @@
+---
+title: SiteConnectorSummary
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# SiteConnectorSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.SiteConnectorSummary`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `Hostname` | `string` | read/write | — |
+| `QueueType` | `string` | read/write | — |
+| `SiteConnectorId` | `int` | read/write | — |
+| `SiteConnectorName` | `string` | read/write | — |
+| `Validated` | `bool` | read/write | — |
+| `Version` | `string` | read/write | — |
+
+

--- a/docs/types/distributed-engines/SiteMetrics.md
+++ b/docs/types/distributed-engines/SiteMetrics.md
@@ -1,0 +1,25 @@
+---
+title: SiteMetrics
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# SiteMetrics
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.SiteMetrics`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `MetricDisplayName` | `string` | read/write | — |
+| `MetricName` | `string` | read/write | — |
+| `MetricValue` | `int` | read/write | — |
+
+

--- a/docs/types/distributed-engines/SiteProcessLocationType.md
+++ b/docs/types/distributed-engines/SiteProcessLocationType.md
@@ -1,0 +1,20 @@
+---
+title: SiteProcessLocationType
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# SiteProcessLocationType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SiteProcessLocationType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `UseWebsite` | _(default)_ |
+| `UseDistributedEngine` | _(default)_ |
+
+

--- a/docs/types/distributed-engines/SiteSummary.md
+++ b/docs/types/distributed-engines/SiteSummary.md
@@ -1,0 +1,33 @@
+---
+title: SiteSummary
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# SiteSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.SiteSummary`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `IsLocal` | `bool` | read/write | — |
+| `LastActivity` | `DateTime?` | read/write | — |
+| `NumEnginesMissingNetFramework` | `int` | read/write | — |
+| `numEnginesWithoutAbilityToRestartService` | `int` | read/write | — |
+| `OfflineEngineCount` | `int` | read/write | — |
+| `OnlineEngineCount` | `int` | read/write | — |
+| `showEngineVersionUpdateBlocklistBannerMessage` | `bool` | read/write | — |
+| `SiteId` | `int` | read/write | — |
+| `SiteMetrics` | `SiteMetrics[]` | read/write | — |
+| `SiteName` | `string` | read/write | — |
+
+

--- a/docs/types/distributed-engines/Validation.md
+++ b/docs/types/distributed-engines/Validation.md
@@ -1,0 +1,24 @@
+---
+title: Validation
+parent: Distributed Engines
+grand_parent: Types
+---
+
+# Validation
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.DistributedEngines.Validation`  
+**Namespace:** `Thycotic.PowerShell.DistributedEngines`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `IsSuccessful` | `bool` | read/write | — |
+| `Message` | `string` | read/write | — |
+
+

--- a/docs/types/distributed-engines/readme.md
+++ b/docs/types/distributed-engines/readme.md
@@ -1,0 +1,11 @@
+---
+title: Distributed Engines
+parent: Types
+has_children: true
+---
+
+# Distributed Engines
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/event-pipeline-policy/Activity.md
+++ b/docs/types/event-pipeline-policy/Activity.md
@@ -1,0 +1,40 @@
+---
+title: Activity
+parent: Event Pipeline Policy
+grand_parent: Types
+---
+
+# Activity
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipelinePolicy.Activity`  
+**Namespace:** `Thycotic.PowerShell.EventPipelinePolicy`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Duration` | `string` | read/write | — |
+| `EndDateTime` | `DateTime?` | read/write | — |
+| `EventAction` | `string` | read/write | — |
+| `EventEntityType` | `string` | read/write | — |
+| `EventPipelineDescription` | `string` | read/write | — |
+| `EventPipelineId` | `int` | read/write | — |
+| `EventPipelineName` | `string` | read/write | — |
+| `EventPipelinePolicyRunId` | `string` | read/write | — |
+| `EventPipelineTaskDescription` | `string` | read/write | — |
+| `EventPipelineTaskId` | `int` | read/write | — |
+| `EventPipelineTaskName` | `string` | read/write | — |
+| `ItemId` | `int` | read/write | — |
+| `ItemName` | `string` | read/write | — |
+| `Notes` | `string` | read/write | — |
+| `QueuedDateTime` | `DateTime?` | read/write | — |
+| `RunOrder` | `int` | read/write | — |
+| `StartDateTime` | `DateTime?` | read/write | — |
+| `Status` | `EventPipelineStatus` | read/write | — |
+
+

--- a/docs/types/event-pipeline-policy/List.md
+++ b/docs/types/event-pipeline-policy/List.md
@@ -1,0 +1,31 @@
+---
+title: List
+parent: Event Pipeline Policy
+grand_parent: Types
+---
+
+# List
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipelinePolicy.List`  
+**Namespace:** `Thycotic.PowerShell.EventPipelinePolicy`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `CreatedDate` | `DateTime?` | read/write | — |
+| `EventEntityTypeId` | `EventEntityType` | read/write | — |
+| `EventPipelinePolicyDescription` | `string` | read/write | — |
+| `EventPipelinePolicyId` | `int` | read/write | — |
+| `EventPipelinePolicyName` | `string` | read/write | — |
+| `IsSystem` | `bool` | read/write | — |
+| `LastModifiedDate` | `DateTime?` | read/write | — |
+| `LastModifiedDisplayName` | `string` | read/write | — |
+
+

--- a/docs/types/event-pipeline-policy/Policy.md
+++ b/docs/types/event-pipeline-policy/Policy.md
@@ -1,0 +1,32 @@
+---
+title: Policy
+parent: Event Pipeline Policy
+grand_parent: Types
+---
+
+# Policy
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipelinePolicy.Policy`  
+**Namespace:** `Thycotic.PowerShell.EventPipelinePolicy`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `CreatedDate` | `DateTime?` | read/write | — |
+| `EventEntityTypeId` | `EventEntityType` | read/write | — |
+| `EventPipelinePolicyDescription` | `string` | read/write | — |
+| `EventPipelinePolicyId` | `int` | read/write | — |
+| `EventPipelinePolicyName` | `string` | read/write | — |
+| `IsSystem` | `bool` | read/write | — |
+| `LastModifiedDate` | `DateTime?` | read/write | — |
+| `LastModifiedDisplayName` | `string` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+
+

--- a/docs/types/event-pipeline-policy/readme.md
+++ b/docs/types/event-pipeline-policy/readme.md
@@ -1,0 +1,11 @@
+---
+title: Event Pipeline Policy
+parent: Types
+has_children: true
+---
+
+# Event Pipeline Policy
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/event-pipeline/FilterSetting.md
+++ b/docs/types/event-pipeline/FilterSetting.md
@@ -1,0 +1,30 @@
+---
+title: FilterSetting
+parent: Event Pipeline
+grand_parent: Types
+---
+
+# FilterSetting
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipeline.FilterSetting`  
+**Namespace:** `Thycotic.PowerShell.EventPipeline`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `EventPipelineFilterMapId` | `int` | read/write | — |
+| `EventPipelineFilterSettingValueMapId` | `int` | read/write | — |
+| `OverrideDefault` | `bool` | read/write | — |
+| `SettingDisplay` | `string` | read/write | — |
+| `SettingDisplayValue` | `string` | read/write | — |
+| `SettingId` | `int` | read/write | — |
+| `SettingValue` | `string` | read/write | — |
+| `UsingDefault` | `bool` | read/write | — |
+
+

--- a/docs/types/event-pipeline/FilterView.md
+++ b/docs/types/event-pipeline/FilterView.md
@@ -1,0 +1,30 @@
+---
+title: FilterView
+parent: Event Pipeline
+grand_parent: Types
+---
+
+# FilterView
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipeline.FilterView`  
+**Namespace:** `Thycotic.PowerShell.EventPipeline`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `EventEntityTypeId` | `EventEntityType` | read/write | — |
+| `EventPipelineFilterDescription` | `string` | read/write | — |
+| `EventPipelineFilterDisplayName` | `string` | read/write | — |
+| `EventPipelineFilterId` | `int` | read/write | — |
+| `EventPipelineFilterMapId` | `int` | read/write | — |
+| `EventPipelineFilterName` | `string` | read/write | — |
+| `Settings` | `FilterSetting[]` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+
+

--- a/docs/types/event-pipeline/List.md
+++ b/docs/types/event-pipeline/List.md
@@ -1,0 +1,37 @@
+---
+title: List
+parent: Event Pipeline
+grand_parent: Types
+---
+
+# List
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipeline.List`  
+**Namespace:** `Thycotic.PowerShell.EventPipeline`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `CreatedDate` | `DateTime?` | read/write | — |
+| `EventEntityTypeId` | `EventEntityType` | read/write | — |
+| `EventPipelineDescription` | `string` | read/write | — |
+| `EventPipelineId` | `int` | read/write | — |
+| `EventPipelineName` | `string` | read/write | — |
+| `EventPipelinePolicyId` | `int` | read/write | — |
+| `EventPipelinePolicyMapId` | `int` | read/write | — |
+| `FilterList` | `FilterView[]` | read/write | — |
+| `IsSystem` | `bool` | read/write | — |
+| `LastModifiedDate` | `DateTime?` | read/write | — |
+| `LastModifiedDisplayName` | `string` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+| `TaskList` | `TaskView[]` | read/write | — |
+| `Triggers` | `TriggerView[]` | read/write | — |
+
+

--- a/docs/types/event-pipeline/RunView.md
+++ b/docs/types/event-pipeline/RunView.md
@@ -1,0 +1,37 @@
+---
+title: RunView
+parent: Event Pipeline
+grand_parent: Types
+---
+
+# RunView
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipeline.RunView`  
+**Namespace:** `Thycotic.PowerShell.EventPipeline`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Description` | `string` | read/write | — |
+| `Duration` | `string` | read/write | — |
+| `EndDate` | `DateTime?` | read/write | — |
+| `EntityTypeName` | `string` | read/write | — |
+| `EventDateTime` | `DateTime?` | read/write | — |
+| `EventDetails` | `string` | read/write | — |
+| `EventName` | `string` | read/write | — |
+| `EventPipelineId` | `int` | read/write | — |
+| `EventPipelinePolicyRunId` | `string` | read/write | — |
+| `ItemId` | `int` | read/write | — |
+| `ItemName` | `string` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `QueuedDate` | `DateTime?` | read/write | — |
+| `StartDate` | `DateTime?` | read/write | — |
+| `Status` | `EventPipelineStatus` | read/write | — |
+
+

--- a/docs/types/event-pipeline/Summary.md
+++ b/docs/types/event-pipeline/Summary.md
@@ -1,0 +1,34 @@
+---
+title: Summary
+parent: Event Pipeline
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipeline.Summary`  
+**Namespace:** `Thycotic.PowerShell.EventPipeline`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `CreatedDate` | `DateTime?` | read/write | — |
+| `EventEntityTypeId` | `EventEntityType` | read/write | — |
+| `EventPipelineDescription` | `string` | read/write | — |
+| `EventPipelineId` | `int` | read/write | — |
+| `EventPipelineName` | `string` | read/write | — |
+| `EventPipelinePolicyId` | `int` | read/write | — |
+| `EventPipelinePolicyMapId` | `int` | read/write | — |
+| `IsSystem` | `bool` | read/write | — |
+| `LastModifiedDate` | `DateTime?` | read/write | — |
+| `LastModifiedDisplayName` | `string` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+
+

--- a/docs/types/event-pipeline/TaskSetting.md
+++ b/docs/types/event-pipeline/TaskSetting.md
@@ -1,0 +1,30 @@
+---
+title: TaskSetting
+parent: Event Pipeline
+grand_parent: Types
+---
+
+# TaskSetting
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipeline.TaskSetting`  
+**Namespace:** `Thycotic.PowerShell.EventPipeline`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `EventPipelineTaskMapId` | `int` | read/write | — |
+| `EventPipelineTaskSettingValueMapId` | `int` | read/write | — |
+| `OverrideDefault` | `bool` | read/write | — |
+| `SettingDisplay` | `string` | read/write | — |
+| `SettingDisplayValue` | `string` | read/write | — |
+| `SettingId` | `int` | read/write | — |
+| `SettingValue` | `string` | read/write | — |
+| `UsingDefault` | `bool` | read/write | — |
+
+

--- a/docs/types/event-pipeline/TaskView.md
+++ b/docs/types/event-pipeline/TaskView.md
@@ -1,0 +1,31 @@
+---
+title: TaskView
+parent: Event Pipeline
+grand_parent: Types
+---
+
+# TaskView
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipeline.TaskView`  
+**Namespace:** `Thycotic.PowerShell.EventPipeline`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `EventEntityTypeId` | `EventEntityType` | read/write | — |
+| `EventPipelineTaskDescription` | `string` | read/write | — |
+| `EventPipelineTaskDisplayName` | `string` | read/write | — |
+| `EventPipelineTaskId` | `int` | read/write | — |
+| `EventPipelineTaskMapId` | `int` | read/write | — |
+| `EventPipelineTaskName` | `string` | read/write | — |
+| `IsMultiSelect` | `bool` | read/write | — |
+| `Settings` | `TaskSetting[]` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+
+

--- a/docs/types/event-pipeline/TriggerView.md
+++ b/docs/types/event-pipeline/TriggerView.md
@@ -1,0 +1,28 @@
+---
+title: TriggerView
+parent: Event Pipeline
+grand_parent: Types
+---
+
+# TriggerView
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.EventPipeline.TriggerView`  
+**Namespace:** `Thycotic.PowerShell.EventPipeline`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `EntityTypeDisplayName` | `string` | read/write | — |
+| `EventActionId` | `int` | read/write | — |
+| `EventEntityTypeId` | `EventEntityType` | read/write | — |
+| `EventPipelineId` | `int` | read/write | — |
+| `EventPipelineTriggerId` | `int` | read/write | — |
+| `TriggerDisplayName` | `string` | read/write | — |
+
+

--- a/docs/types/event-pipeline/readme.md
+++ b/docs/types/event-pipeline/readme.md
@@ -1,0 +1,11 @@
+---
+title: Event Pipeline
+parent: Types
+has_children: true
+---
+
+# Event Pipeline
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/event-pipelines/EventEntityType.md
+++ b/docs/types/event-pipelines/EventEntityType.md
@@ -1,0 +1,51 @@
+---
+title: EventEntityType
+parent: Event Pipelines
+grand_parent: Types
+---
+
+# EventEntityType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.EventEntityType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Unknown` | `0` |
+| `User` | `1` |
+| `Folder` | `2` |
+| `Role` | `3` |
+| `RolePermission` | `4` |
+| `Configuration` | `5` |
+| `Group` | `6` |
+| `IpAddressRange` | `7` |
+| `Secret` | `10001` |
+| `UnlimitedAdmin` | `10002` |
+| `ExportSecrets` | `10003` |
+| `ImportSecrets` | `10004` |
+| `UserAudit` | `10005` |
+| `SecretTemplate` | `10006` |
+| `Licenses` | `10007` |
+| `ScriptPowerShell` | `10008` |
+| `SecretPolicy` | `10009` |
+| `ScriptSsh` | `10010` |
+| `ScriptSsql` | `10011` |
+| `Encryption` | `10012` |
+| `Site` | `10013` |
+| `Engine` | `10014` |
+| `SiteConnector` | `10015` |
+| `SecurityAnalyticsConfiguration` | `10016` |
+| `DualControl` | `10017` |
+| `Tls` | `10018` |
+| `PasswordChanger` | `10019` |
+| `CharacterSet` | `10020` |
+| `PasswordRequirement` | `10021` |
+| `Domain` | `10022` |
+| `BackupConfiguration` | `10023` |
+| `SecretServerSettings` | `10024` |
+| `AutoExport` | `10025` |
+
+

--- a/docs/types/event-pipelines/EventPipelineStatus.md
+++ b/docs/types/event-pipelines/EventPipelineStatus.md
@@ -1,0 +1,24 @@
+---
+title: EventPipelineStatus
+parent: Event Pipelines
+grand_parent: Types
+---
+
+# EventPipelineStatus
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.EventPipelineStatus`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Failed` | _(default)_ |
+| `Success` | _(default)_ |
+| `Skipped` | _(default)_ |
+| `Processing` | _(default)_ |
+| `Pending` | _(default)_ |
+| `Scheduled` | _(default)_ |
+
+

--- a/docs/types/event-pipelines/readme.md
+++ b/docs/types/event-pipelines/readme.md
@@ -1,0 +1,11 @@
+---
+title: Event Pipelines
+parent: Types
+has_children: true
+---
+
+# Event Pipelines
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/folder-permissions/Permission.md
+++ b/docs/types/folder-permissions/Permission.md
@@ -1,0 +1,34 @@
+---
+title: Permission
+parent: Folder Permissions
+grand_parent: Types
+---
+
+# Permission
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.FolderPermissions.Permission`  
+**Namespace:** `Thycotic.PowerShell.FolderPermissions`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `domainName` | `string` | read/write | — |
+| `FolderAccessRoleId` | `int` | read/write | — |
+| `FolderAccessRoleName` | `string` | read/write | — |
+| `FolderId` | `int` | read/write | — |
+| `GroupId` | `int` | read/write | — |
+| `GroupName` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `KnownAs` | `string` | read/write | — |
+| `SecretAccessRoleId` | `int` | read/write | — |
+| `SecretAccessRoleName` | `string` | read/write | — |
+| `UserId` | `int` | read/write | — |
+| `Username` | `string` | read/write | — |
+
+

--- a/docs/types/folder-permissions/Summary.md
+++ b/docs/types/folder-permissions/Summary.md
@@ -1,0 +1,27 @@
+---
+title: Summary
+parent: Folder Permissions
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.FolderPermissions.Summary`  
+**Namespace:** `Thycotic.PowerShell.FolderPermissions`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `FolderAccessRoleId` | `int` | read/write | — |
+| `FolderAccessRoleName` | `string` | read/write | — |
+| `GroupId` | `int` | read/write | — |
+| `SecretAccessRoleId` | `int` | read/write | — |
+| `SecretAccessRoleName` | `string` | read/write | — |
+
+

--- a/docs/types/folder-permissions/readme.md
+++ b/docs/types/folder-permissions/readme.md
@@ -1,0 +1,11 @@
+---
+title: Folder Permissions
+parent: Types
+has_children: true
+---
+
+# Folder Permissions
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/folders/AuditSummary.md
+++ b/docs/types/folders/AuditSummary.md
@@ -1,0 +1,27 @@
+---
+title: AuditSummary
+parent: Folders
+grand_parent: Types
+---
+
+# AuditSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Folders.AuditSummary`  
+**Namespace:** `Thycotic.PowerShell.Folders`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Action` | `string` | read/write | — |
+| `AuditFolderId` | `int` | read/write | — |
+| `DateRecorded` | `DateTime?` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `Notes` | `string` | read/write | — |
+
+

--- a/docs/types/folders/DetailTemplateView.md
+++ b/docs/types/folders/DetailTemplateView.md
@@ -1,0 +1,24 @@
+---
+title: DetailTemplateView
+parent: Folders
+grand_parent: Types
+---
+
+# DetailTemplateView
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Folders.DetailTemplateView`  
+**Namespace:** `Thycotic.PowerShell.Folders`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/folders/DetailView.md
+++ b/docs/types/folders/DetailView.md
@@ -1,0 +1,27 @@
+---
+title: DetailView
+parent: Folders
+grand_parent: Types
+---
+
+# DetailView
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Folders.DetailView`  
+**Namespace:** `Thycotic.PowerShell.Folders`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Actions` | `string[]` | read/write | — |
+| `AllowedTemplates` | `DetailTemplateView[]` | read/write | — |
+| `FolderWarning` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/folders/Folder.md
+++ b/docs/types/folders/Folder.md
@@ -1,0 +1,32 @@
+---
+title: Folder
+parent: Folders
+grand_parent: Types
+---
+
+# Folder
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Folders.Folder`  
+**Namespace:** `Thycotic.PowerShell.Folders`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ChildFolders` | `Folder[]` | read/write | — |
+| `FolderName` | `string` | read/write | — |
+| `FolderPath` | `string` | read/write | — |
+| `FolderTypeId` | `int` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `InheritPermissions` | `bool` | read/write | — |
+| `InheritSecretPolicy` | `bool` | read/write | — |
+| `ParentFolderId` | `int` | read/write | — |
+| `SecretPolicyId` | `int` | read/write | — |
+| `SecretTemplates` | `FolderTemplate[]` | read/write | — |
+
+

--- a/docs/types/folders/FolderTemplate.md
+++ b/docs/types/folders/FolderTemplate.md
@@ -1,0 +1,26 @@
+---
+title: FolderTemplate
+parent: Folders
+grand_parent: Types
+---
+
+# FolderTemplate
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Folders.FolderTemplate`  
+**Namespace:** `Thycotic.PowerShell.Folders`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `SecretCount` | `int` | read/write | — |
+
+

--- a/docs/types/folders/Lookup.md
+++ b/docs/types/folders/Lookup.md
@@ -1,0 +1,24 @@
+---
+title: Lookup
+parent: Folders
+grand_parent: Types
+---
+
+# Lookup
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Folders.Lookup`  
+**Namespace:** `Thycotic.PowerShell.Folders`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `int` | read/write | — |
+| `Value` | `string` | read/write | — |
+
+

--- a/docs/types/folders/Summary.md
+++ b/docs/types/folders/Summary.md
@@ -1,0 +1,30 @@
+---
+title: Summary
+parent: Folders
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Folders.Summary`  
+**Namespace:** `Thycotic.PowerShell.Folders`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `FolderName` | `string` | read/write | — |
+| `FolderPath` | `string` | read/write | — |
+| `FolderTypeId` | `int` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `InheritPermissions` | `bool` | read/write | — |
+| `InheritSecretPolicy` | `bool` | read/write | — |
+| `ParentFolderId` | `int` | read/write | — |
+| `SecretPolicyId` | `int` | read/write | — |
+
+

--- a/docs/types/folders/readme.md
+++ b/docs/types/folders/readme.md
@@ -1,0 +1,11 @@
+---
+title: Folders
+parent: Types
+has_children: true
+---
+
+# Folders
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/groups/Group.md
+++ b/docs/types/groups/Group.md
@@ -1,0 +1,38 @@
+---
+title: Group
+parent: Groups
+grand_parent: Types
+---
+
+# Group
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Groups.Group`  
+**Namespace:** `Thycotic.PowerShell.Groups`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AdGuid` | `string` | read/write | — |
+| `CanEditMembers` | `bool` | read/write | — |
+| `Created` | `DateTime?` | read/write | — |
+| `DomainId` | `int` | read/write | — |
+| `DomainName` | `string` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `HasGroupOwners` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `IsEditable` | `bool` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `OwnerGroups` | `object[]` | read/write | — |
+| `Owners` | `GroupOwner[]` | read/write | — |
+| `OwnerUsers` | `object[]` | read/write | — |
+| `Synchronized` | `bool` | read/write | — |
+| `SynchronizeNow` | `bool` | read/write | — |
+| `SystemGroup` | `bool` | read/write | — |
+
+

--- a/docs/types/groups/GroupOwner.md
+++ b/docs/types/groups/GroupOwner.md
@@ -1,0 +1,25 @@
+---
+title: GroupOwner
+parent: Groups
+grand_parent: Types
+---
+
+# GroupOwner
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Groups.GroupOwner`  
+**Namespace:** `Thycotic.PowerShell.Groups`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `GroupId` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `UserId` | `int` | read/write | — |
+
+

--- a/docs/types/groups/Lookup.md
+++ b/docs/types/groups/Lookup.md
@@ -1,0 +1,24 @@
+---
+title: Lookup
+parent: Groups
+grand_parent: Types
+---
+
+# Lookup
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Groups.Lookup`  
+**Namespace:** `Thycotic.PowerShell.Groups`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `int` | read/write | — |
+| `Value` | `string` | read/write | — |
+
+

--- a/docs/types/groups/RoleSummary.md
+++ b/docs/types/groups/RoleSummary.md
@@ -1,0 +1,24 @@
+---
+title: RoleSummary
+parent: Groups
+grand_parent: Types
+---
+
+# RoleSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Groups.RoleSummary`  
+**Namespace:** `Thycotic.PowerShell.Groups`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Name` | `string` | read/write | — |
+| `RoleId` | `int` | read/write | — |
+
+

--- a/docs/types/groups/Summary.md
+++ b/docs/types/groups/Summary.md
@@ -1,0 +1,33 @@
+---
+title: Summary
+parent: Groups
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Groups.Summary`  
+**Namespace:** `Thycotic.PowerShell.Groups`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Created` | `DateTime?` | read/write | — |
+| `DomainGuid` | `string` | read/write | — |
+| `DomainId` | `int` | read/write | — |
+| `DomainName` | `string` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `isPlatform` | `bool` | read/write | — |
+| `MemberCount` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `Synchronized` | `bool` | read/write | — |
+| `SynchronizeNow` | `bool` | read/write | — |
+
+

--- a/docs/types/groups/User.md
+++ b/docs/types/groups/User.md
@@ -1,0 +1,28 @@
+---
+title: User
+parent: Groups
+grand_parent: Types
+---
+
+# User
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Groups.User`  
+**Namespace:** `Thycotic.PowerShell.Groups`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `GroupDomainId` | `int` | read/write | — |
+| `GroupId` | `int` | read/write | — |
+| `GroupName` | `string` | read/write | — |
+| `UserDomainId` | `int` | read/write | — |
+| `UserId` | `int` | read/write | — |
+| `Username` | `string` | read/write | — |
+
+

--- a/docs/types/groups/UserSummary.md
+++ b/docs/types/groups/UserSummary.md
@@ -1,0 +1,32 @@
+---
+title: UserSummary
+parent: Groups
+grand_parent: Types
+---
+
+# UserSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Groups.UserSummary`  
+**Namespace:** `Thycotic.PowerShell.Groups`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DisplayName` | `string` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `GroupDomainId` | `int` | read/write | — |
+| `GroupDomainName` | `string` | read/write | — |
+| `GroupId` | `int` | read/write | — |
+| `GroupName` | `string` | read/write | — |
+| `UserDomainId` | `int` | read/write | — |
+| `UserDomainName` | `string` | read/write | — |
+| `UserId` | `int` | read/write | — |
+| `Username` | `string` | read/write | — |
+
+

--- a/docs/types/groups/readme.md
+++ b/docs/types/groups/readme.md
@@ -1,0 +1,11 @@
+---
+title: Groups
+parent: Types
+has_children: true
+---
+
+# Groups
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/ipaddress-restrictions/Group.md
+++ b/docs/types/ipaddress-restrictions/Group.md
@@ -1,0 +1,27 @@
+---
+title: Group
+parent: Ipaddress Restrictions
+grand_parent: Types
+---
+
+# Group
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.IpRestrictions.Group`  
+**Namespace:** `Thycotic.PowerShell.IpRestrictions`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `GroupId` | `int` | read/write | — |
+| `GroupName` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `IpAddressRestrictionId` | `int` | read/write | — |
+| `IpAddressRestrictionName` | `string` | read/write | — |
+
+

--- a/docs/types/ipaddress-restrictions/IpRestriction.md
+++ b/docs/types/ipaddress-restrictions/IpRestriction.md
@@ -1,0 +1,25 @@
+---
+title: IpRestriction
+parent: Ipaddress Restrictions
+grand_parent: Types
+---
+
+# IpRestriction
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.IpRestrictions.IpRestriction`  
+**Namespace:** `Thycotic.PowerShell.IpRestrictions`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `Range` | `string` | read/write | — |
+
+

--- a/docs/types/ipaddress-restrictions/User.md
+++ b/docs/types/ipaddress-restrictions/User.md
@@ -1,0 +1,28 @@
+---
+title: User
+parent: Ipaddress Restrictions
+grand_parent: Types
+---
+
+# User
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.IpRestrictions.User`  
+**Namespace:** `Thycotic.PowerShell.IpRestrictions`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `int` | read/write | — |
+| `IpAddressRestrictionId` | `int` | read/write | — |
+| `IpAddressRestrictionName` | `string` | read/write | — |
+| `UserDisplayName` | `string` | read/write | — |
+| `UserId` | `int` | read/write | — |
+| `Username` | `string` | read/write | — |
+
+

--- a/docs/types/ipaddress-restrictions/readme.md
+++ b/docs/types/ipaddress-restrictions/readme.md
@@ -1,0 +1,11 @@
+---
+title: Ipaddress Restrictions
+parent: Types
+has_children: true
+---
+
+# Ipaddress Restrictions
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/lists/Category.md
+++ b/docs/types/lists/Category.md
@@ -1,0 +1,24 @@
+---
+title: Category
+parent: Lists
+grand_parent: Types
+---
+
+# Category
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Lists.Category`  
+**Namespace:** `Thycotic.PowerShell.Lists`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CategorizedListId` | `string` | read/write | — |
+| `CategoryName` | `string` | read/write | — |
+
+

--- a/docs/types/lists/Item.md
+++ b/docs/types/lists/Item.md
@@ -1,0 +1,26 @@
+---
+title: Item
+parent: Lists
+grand_parent: Types
+---
+
+# Item
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Lists.Item`  
+**Namespace:** `Thycotic.PowerShell.Lists`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CategorizedListId` | `Guid` | read/write | — |
+| `CategorizedListItemId` | `string` | read/write | — |
+| `Category` | `string` | read/write | — |
+| `Value` | `string` | read/write | — |
+
+

--- a/docs/types/lists/List.md
+++ b/docs/types/lists/List.md
@@ -1,0 +1,27 @@
+---
+title: List
+parent: Lists
+grand_parent: Types
+---
+
+# List
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Lists.List`  
+**Namespace:** `Thycotic.PowerShell.Lists`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `CategorizedListId` | `Guid` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `Items` | `Item[]` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/lists/Summary.md
+++ b/docs/types/lists/Summary.md
@@ -1,0 +1,27 @@
+---
+title: Summary
+parent: Lists
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Lists.Summary`  
+**Namespace:** `Thycotic.PowerShell.Lists`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `CategorizedListId` | `Guid` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `NumOptions` | `int` | read/write | — |
+
+

--- a/docs/types/lists/SummaryList.md
+++ b/docs/types/lists/SummaryList.md
@@ -1,0 +1,24 @@
+---
+title: SummaryList
+parent: Lists
+grand_parent: Types
+---
+
+# SummaryList
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Lists.SummaryList`  
+**Namespace:** `Thycotic.PowerShell.Lists`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CategorizedListId` | `Guid` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/lists/readme.md
+++ b/docs/types/lists/readme.md
@@ -1,0 +1,11 @@
+---
+title: Lists
+parent: Types
+has_children: true
+---
+
+# Lists
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/logging/LogLevel.md
+++ b/docs/types/logging/LogLevel.md
@@ -1,0 +1,26 @@
+---
+title: LogLevel
+parent: Logging
+grand_parent: Types
+---
+
+# LogLevel
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.LogLevel`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Emergency` | _(default)_ |
+| `Alert` | _(default)_ |
+| `Critical` | _(default)_ |
+| `Error` | _(default)_ |
+| `Warning` | _(default)_ |
+| `Notice` | _(default)_ |
+| `Information` | _(default)_ |
+| `Debug` | _(default)_ |
+
+

--- a/docs/types/logging/readme.md
+++ b/docs/types/logging/readme.md
@@ -1,0 +1,11 @@
+---
+title: Logging
+parent: Types
+has_children: true
+---
+
+# Logging
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/metadata/Field.md
+++ b/docs/types/metadata/Field.md
@@ -1,0 +1,41 @@
+---
+title: Field
+parent: Metadata
+grand_parent: Types
+---
+
+# Field
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Metadata.Field`  
+**Namespace:** `Thycotic.PowerShell.Metadata`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CreateDateTime` | `DateTime?` | read/write | — |
+| `CreateUserId` | `int` | read/write | — |
+| `CreateUserName` | `string` | read/write | — |
+| `ItemId` | `int` | read/write | — |
+| `MetadataFieldId` | `int` | read/write | — |
+| `MetadataFieldName` | `string` | read/write | — |
+| `MetadataFieldSectionId` | `int` | read/write | — |
+| `MetadataFieldSectionName` | `string` | read/write | — |
+| `MetadataFieldTypeId` | `int` | read/write | — |
+| `MetadataFieldTypeName` | `string` | read/write | — |
+| `MetadataItemDataId` | `int` | read/write | — |
+| `MetadataTypeName` | `string` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+| `ValueBit` | `bool` | read/write | — |
+| `ValueDateTime` | `DateTime?` | read/write | — |
+| `ValueInt` | `int` | read/write | — |
+| `ValueNumber` | `double` | read/write | — |
+| `ValueString` | `string` | read/write | — |
+| `ValueUserDisplayName` | `string` | read/write | — |
+
+

--- a/docs/types/metadata/FieldSectionSummary.md
+++ b/docs/types/metadata/FieldSectionSummary.md
@@ -1,0 +1,28 @@
+---
+title: FieldSectionSummary
+parent: Metadata
+grand_parent: Types
+---
+
+# FieldSectionSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Metadata.FieldSectionSummary`  
+**Namespace:** `Thycotic.PowerShell.Metadata`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Actions` | `MetadataFieldSectionAction[]` | read/write | — |
+| `MetadataFieldSectionDescription` | `string` | read/write | — |
+| `MetadataFieldSectionId` | `int` | read/write | — |
+| `MetadataFieldSectionName` | `string` | read/write | — |
+| `RequiresAdministerMetadata` | `bool` | read/write | — |
+| `RequiresEntityEdit` | `bool` | read/write | — |
+
+

--- a/docs/types/metadata/FieldSummary.md
+++ b/docs/types/metadata/FieldSummary.md
@@ -1,0 +1,29 @@
+---
+title: FieldSummary
+parent: Metadata
+grand_parent: Types
+---
+
+# FieldSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Metadata.FieldSummary`  
+**Namespace:** `Thycotic.PowerShell.Metadata`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `containsPersonalInformation` | `bool` | read/write | — |
+| `DefaultSortOrder` | `int` | read/write | — |
+| `FieldDataType` | `MetadataFieldDataType` | read/write | — |
+| `MetadataFieldId` | `int` | read/write | — |
+| `MetadataFieldName` | `string` | read/write | — |
+| `MetadataFieldSectionId` | `int` | read/write | — |
+| `MetadataFieldSectionName` | `string` | read/write | — |
+
+

--- a/docs/types/metadata/History.md
+++ b/docs/types/metadata/History.md
@@ -1,0 +1,44 @@
+---
+title: History
+parent: Metadata
+grand_parent: Types
+---
+
+# History
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Metadata.History`  
+**Namespace:** `Thycotic.PowerShell.Metadata`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `containsPersonalInformation` | `bool` | read/write | — |
+| `CreateDateTime` | `DateTime?` | read/write | — |
+| `CreateUserId` | `int` | read/write | — |
+| `CreateUserName` | `string` | read/write | — |
+| `ItemId` | `int` | read/write | — |
+| `MetadataFieldDataType` | `MetadataFieldDataType` | read/write | — |
+| `MetadataFieldId` | `int` | read/write | — |
+| `MetadataFieldName` | `string` | read/write | — |
+| `MetadataFieldSectionId` | `int` | read/write | — |
+| `MetadataFieldSectionName` | `string` | read/write | — |
+| `MetadataFieldTypeName` | `string` | read/write | — |
+| `MetadataItemDataHistoryId` | `int` | read/write | — |
+| `MetadataItemDataId` | `int` | read/write | — |
+| `MetadataType` | `MetadataType` | read/write | — |
+| `MetadataTypeName` | `string` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+| `ValueBit` | `bool` | read/write | — |
+| `ValueDateTime` | `DateTime?` | read/write | — |
+| `ValueInt` | `int` | read/write | — |
+| `ValueNumber` | `double` | read/write | — |
+| `ValueString` | `string` | read/write | — |
+| `ValueUserDisplayName` | `string` | read/write | — |
+
+

--- a/docs/types/metadata/MetadataFieldDataType.md
+++ b/docs/types/metadata/MetadataFieldDataType.md
@@ -1,0 +1,23 @@
+---
+title: MetadataFieldDataType
+parent: Metadata
+grand_parent: Types
+---
+
+# MetadataFieldDataType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.MetadataFieldDataType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `String` | _(default)_ |
+| `Boolean` | _(default)_ |
+| `Number` | _(default)_ |
+| `DateTime` | _(default)_ |
+| `User` | _(default)_ |
+
+

--- a/docs/types/metadata/MetadataFieldSectionAction.md
+++ b/docs/types/metadata/MetadataFieldSectionAction.md
@@ -1,0 +1,22 @@
+---
+title: MetadataFieldSectionAction
+parent: Metadata
+grand_parent: Types
+---
+
+# MetadataFieldSectionAction
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.MetadataFieldSectionAction`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `EditSection` | _(default)_ |
+| `AddField` | _(default)_ |
+| `EditItem` | _(default)_ |
+| `DeleteItem` | _(default)_ |
+
+

--- a/docs/types/metadata/MetadataType.md
+++ b/docs/types/metadata/MetadataType.md
@@ -1,0 +1,22 @@
+---
+title: MetadataType
+parent: Metadata
+grand_parent: Types
+---
+
+# MetadataType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.MetadataType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Secret` | _(default)_ |
+| `User` | _(default)_ |
+| `Folder` | _(default)_ |
+| `Group` | _(default)_ |
+
+

--- a/docs/types/metadata/Summary.md
+++ b/docs/types/metadata/Summary.md
@@ -1,0 +1,43 @@
+---
+title: Summary
+parent: Metadata
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Metadata.Summary`  
+**Namespace:** `Thycotic.PowerShell.Metadata`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `containsPersonalInformation` | `bool` | read/write | — |
+| `CreateDateTime` | `DateTime?` | read/write | — |
+| `CreateUserId` | `int` | read/write | — |
+| `CreateUserName` | `string` | read/write | — |
+| `ItemId` | `int` | read/write | — |
+| `MetadataFieldDataType` | `string` | read/write | — |
+| `MetadataFieldId` | `int` | read/write | — |
+| `MetadataFieldName` | `string` | read/write | — |
+| `MetadataFieldSectionId` | `int` | read/write | — |
+| `MetadataFieldSectionName` | `string` | read/write | — |
+| `MetadataFieldTypeName` | `string` | read/write | — |
+| `MetadataItemDataId` | `int` | read/write | — |
+| `MetadataType` | `MetadataType` | read/write | — |
+| `MetadataTypeName` | `string` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+| `ValueBit` | `bool` | read/write | — |
+| `ValueDateTime` | `DateTime?` | read/write | — |
+| `ValueInt` | `int` | read/write | — |
+| `ValueNumber` | `int` | read/write | — |
+| `ValueString` | `string` | read/write | — |
+| `ValueUserDisplayName` | `string` | read/write | — |
+
+

--- a/docs/types/metadata/readme.md
+++ b/docs/types/metadata/readme.md
@@ -1,0 +1,11 @@
+---
+title: Metadata
+parent: Types
+has_children: true
+---
+
+# Metadata
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/readme.md
+++ b/docs/types/readme.md
@@ -1,0 +1,15 @@
+---
+title: Types
+nav_order: 4
+has_children: true
+---
+
+# Types
+
+Reference for the C# classes and enums exposed by the Thycotic.SecretServer module.
+Each page lists the full type name, namespace, properties, methods, and (for enums) numeric values.
+These pages are auto-generated from the C# source under `src/Thycotic.SecretServer/`.
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/remote-password-changing/AssociatedSecret.md
+++ b/docs/types/remote-password-changing/AssociatedSecret.md
@@ -1,0 +1,28 @@
+---
+title: AssociatedSecret
+parent: Remote Password Changing
+grand_parent: Types
+---
+
+# AssociatedSecret
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Rpc.AssociatedSecret`  
+**Namespace:** `Thycotic.PowerShell.Rpc`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AssociatedSecretId` | `int` | read/write | — |
+| `FolderName` | `string` | read/write | — |
+| `Order` | `int` | read/write | — |
+| `ParentSecretId` | `int` | read/write | — |
+| `SecretName` | `string` | read/write | — |
+| `SecretTemplateName` | `string` | read/write | — |
+
+

--- a/docs/types/remote-password-changing/PasswordType.md
+++ b/docs/types/remote-password-changing/PasswordType.md
@@ -1,0 +1,49 @@
+---
+title: PasswordType
+parent: Remote Password Changing
+grand_parent: Types
+---
+
+# PasswordType
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Rpc.PasswordType`  
+**Namespace:** `Thycotic.PowerShell.Rpc`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `allowsPrivilegedAccount` | `bool` | read/write | — |
+| `CanEdit` | `bool` | read/write | — |
+| `CustomPort` | `int` | read/write | — |
+| `ExitCommand` | `string` | read/write | — |
+| `Fields` | `PasswordTypeField[]` | read/write | — |
+| `HasCommands` | `bool` | read/write | — |
+| `HasLDAPSettings` | `bool` | read/write | — |
+| `HeartbeatScriptArgs` | `string` | read/write | — |
+| `HeartbeatScriptId` | `int` | read/write | — |
+| `IgnoreSSL` | `bool` | read/write | — |
+| `IsWeb` | `bool` | read/write | — |
+| `LdapConnectionSettingsId` | `int` | read/write | — |
+| `LineEnding` | `string` | read/write | — |
+| `MainframeConnectionString` | `string` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `OdbcConnectionString` | `string` | read/write | — |
+| `PasswordTypeId` | `int` | read/write | — |
+| `RpcScriptArgs` | `string` | read/write | — |
+| `RpcScriptId` | `int` | read/write | — |
+| `RunnerType` | `string` | read/write | — |
+| `ScanItemTemplateId` | `int` | read/write | — |
+| `TypeName` | `string` | read/write | — |
+| `UseSSL` | `bool` | read/write | — |
+| `UseUsernameAndPassword` | `bool` | read/write | — |
+| `ValidForTakeover` | `bool` | read/write | — |
+| `WindowsCustomPorts` | `string` | read/write | — |
+
+

--- a/docs/types/remote-password-changing/PasswordTypeField.md
+++ b/docs/types/remote-password-changing/PasswordTypeField.md
@@ -1,0 +1,26 @@
+---
+title: PasswordTypeField
+parent: Remote Password Changing
+grand_parent: Types
+---
+
+# PasswordTypeField
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Rpc.PasswordTypeField`  
+**Namespace:** `Thycotic.PowerShell.Rpc`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `isOptional` | `bool` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `PasswordTypeFieldId` | `int` | read/write | — |
+| `ScanItemFieldId` | `int` | read/write | — |
+
+

--- a/docs/types/remote-password-changing/PasswordTypeSummary.md
+++ b/docs/types/remote-password-changing/PasswordTypeSummary.md
@@ -1,0 +1,38 @@
+---
+title: PasswordTypeSummary
+parent: Remote Password Changing
+grand_parent: Types
+---
+
+# PasswordTypeSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Rpc.PasswordTypeSummary`  
+**Namespace:** `Thycotic.PowerShell.Rpc`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `CanEdit` | `bool` | read/write | — |
+| `HasCommands` | `bool` | read/write | — |
+| `HeartbeatScriptId` | `int` | read/write | — |
+| `IgnoreSsl` | `bool` | read/write | — |
+| `IsWeb` | `bool` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `PasswordTypeId` | `int` | read/write | — |
+| `RequiredEdition` | `string` | read/write | — |
+| `requiredEditionMessage` | `string` | read/write | — |
+| `RpcScriptId` | `int` | read/write | — |
+| `RunnerType` | `string` | read/write | — |
+| `scanItemTemplateActive` | `bool` | read/write | — |
+| `ScanItemTemplateId` | `int` | read/write | — |
+| `scanItemTemplateName` | `string` | read/write | — |
+| `UseSsl` | `bool` | read/write | — |
+
+

--- a/docs/types/remote-password-changing/readme.md
+++ b/docs/types/remote-password-changing/readme.md
@@ -1,0 +1,11 @@
+---
+title: Remote Password Changing
+parent: Types
+has_children: true
+---
+
+# Remote Password Changing
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/reports/Category.md
+++ b/docs/types/reports/Category.md
@@ -1,0 +1,25 @@
+---
+title: Category
+parent: Reports
+grand_parent: Types
+---
+
+# Category
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.Category`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Description` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/reports/CategoryDetail.md
+++ b/docs/types/reports/CategoryDetail.md
@@ -1,0 +1,26 @@
+---
+title: CategoryDetail
+parent: Reports
+grand_parent: Types
+---
+
+# CategoryDetail
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.CategoryDetail`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ReportCategoryDescription` | `string` | read/write | — |
+| `ReportCategoryId` | `int` | read/write | `-1` |
+| `ReportCategoryName` | `string` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+
+

--- a/docs/types/reports/Lookup.md
+++ b/docs/types/reports/Lookup.md
@@ -1,0 +1,24 @@
+---
+title: Lookup
+parent: Reports
+grand_parent: Types
+---
+
+# Lookup
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.Lookup`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `int` | read/write | — |
+| `Value` | `string` | read/write | — |
+
+

--- a/docs/types/reports/Parameter.md
+++ b/docs/types/reports/Parameter.md
@@ -1,0 +1,26 @@
+---
+title: Parameter
+parent: Reports
+grand_parent: Types
+---
+
+# Parameter
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.Parameter`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Name` | `string` | read/write | — |
+| `Value` | `object[]` | read/write | — |
+| `ValueDisplayName` | `string` | read/write | — |
+| `VariableName` | `string` | read/write | — |
+
+

--- a/docs/types/reports/ParameterValue.md
+++ b/docs/types/reports/ParameterValue.md
@@ -1,0 +1,25 @@
+---
+title: ParameterValue
+parent: Reports
+grand_parent: Types
+---
+
+# ParameterValue
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.ParameterValue`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Name` | `string` | read/write | — |
+| `Value` | `object` | read/write | — |
+| `ValueDisplayName` | `string` | read/write | — |
+
+

--- a/docs/types/reports/Report.md
+++ b/docs/types/reports/Report.md
@@ -1,0 +1,33 @@
+---
+title: Report
+parent: Reports
+grand_parent: Types
+---
+
+# Report
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.Report`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CategoryId` | `int` | read/write | — |
+| `ChartType` | `string` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Is3DReport` | `bool` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `PageSize` | `int` | read/write | — |
+| `ReportSql` | `string` | read/write | — |
+| `SystemReport` | `bool` | read/write | — |
+| `UseDatabasePaging` | `bool` | read/write | — |
+
+

--- a/docs/types/reports/ReportFormat.md
+++ b/docs/types/reports/ReportFormat.md
@@ -1,0 +1,20 @@
+---
+title: ReportFormat
+parent: Reports
+grand_parent: Types
+---
+
+# ReportFormat
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.ReportFormat`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Html` | _(default)_ |
+| `Csv` | _(default)_ |
+
+

--- a/docs/types/reports/ReportSchedule.md
+++ b/docs/types/reports/ReportSchedule.md
@@ -1,0 +1,35 @@
+---
+title: ReportSchedule
+parent: Reports
+grand_parent: Types
+---
+
+# ReportSchedule
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.ReportSchedule`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CustomParameterValue` | `string` | read/write | — |
+| `EndDateParameterSpecificDateValue` | `DateTime?` | read/write | — |
+| `EndDateParameterValue` | `string` | read/write | — |
+| `FolderParameter` | `ParameterValue` | read/write | — |
+| `Format` | `ReportFormat` | read/write | — |
+| `GroupParameterValue` | `ParameterValue` | read/write | — |
+| `ReportId` | `int` | read/write | — |
+| `ReportName` | `string` | read/write | — |
+| `Schedule` | `ScheduleView` | read/write | — |
+| `ScheduleReportId` | `int` | read/write | — |
+| `StartDateParameterSpecificDateValue` | `DateTime?` | read/write | — |
+| `StartDateParameterValue` | `string` | read/write | — |
+| `UserParameterValue` | `ParameterValue` | read/write | — |
+
+

--- a/docs/types/reports/ReportScheduleType.md
+++ b/docs/types/reports/ReportScheduleType.md
@@ -1,0 +1,21 @@
+---
+title: ReportScheduleType
+parent: Reports
+grand_parent: Types
+---
+
+# ReportScheduleType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.ReportScheduleType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Daily` | _(default)_ |
+| `Weekly` | _(default)_ |
+| `Monthly` | _(default)_ |
+
+

--- a/docs/types/reports/ScheduleMonthType.md
+++ b/docs/types/reports/ScheduleMonthType.md
@@ -1,0 +1,20 @@
+---
+title: ScheduleMonthType
+parent: Reports
+grand_parent: Types
+---
+
+# ScheduleMonthType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.ScheduleMonthType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `DayOfWeekMonth` | _(default)_ |
+| `DayOfMonth` | _(default)_ |
+
+

--- a/docs/types/reports/ScheduleSummary.md
+++ b/docs/types/reports/ScheduleSummary.md
@@ -1,0 +1,33 @@
+---
+title: ScheduleSummary
+parent: Reports
+grand_parent: Types
+---
+
+# ScheduleSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.ScheduleSummary`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ChangeType` | `string` | read/write | — |
+| `Deleted` | `bool` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `LastRun` | `DateTime?` | read/write | — |
+| `LastRunHistoryId` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `ReportId` | `int` | read/write | — |
+| `ReportName` | `string` | read/write | — |
+| `ScheduleReportId` | `int` | read/write | — |
+| `SendEmail` | `bool` | read/write | — |
+| `StoredReportCount` | `int` | read/write | — |
+
+

--- a/docs/types/reports/ScheduleView.md
+++ b/docs/types/reports/ScheduleView.md
@@ -1,0 +1,46 @@
+---
+title: ScheduleView
+parent: Reports
+grand_parent: Types
+---
+
+# ScheduleView
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.ScheduleView`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AdditionalEmailAddresses` | `string` | read/write | — |
+| `ChangeType` | `ReportScheduleType` | read/write | — |
+| `Days` | `int` | read/write | — |
+| `EmailGroups` | `Subscriber[]` | read/write | — |
+| `Friday` | `bool` | read/write | — |
+| `HealthCheck` | `bool` | read/write | — |
+| `HistorySize` | `int` | read/write | — |
+| `Monday` | `bool` | read/write | — |
+| `MonthlyDay` | `string` | read/write | — |
+| `MonthlyDayOfMonth` | `int` | read/write | — |
+| `MonthlyDayOrder` | `string` | read/write | — |
+| `MonthlyDayOrderRecurrence` | `int` | read/write | — |
+| `MonthlyDayRecurrence` | `int` | read/write | — |
+| `MonthlyScheduleType` | `string` | read/write | — |
+| `Saturday` | `bool` | read/write | — |
+| `ScheduleName` | `string` | read/write | — |
+| `SendEmail` | `bool` | read/write | — |
+| `SendEmailWithHighPriority` | `bool` | read/write | — |
+| `StartingOn` | `DateTime?` | read/write | — |
+| `Sunday` | `bool` | read/write | — |
+| `Thursday` | `bool` | read/write | — |
+| `Tuesday` | `bool` | read/write | — |
+| `Wednesday` | `bool` | read/write | — |
+| `Weeks` | `int` | read/write | — |
+
+

--- a/docs/types/reports/Subscriber.md
+++ b/docs/types/reports/Subscriber.md
@@ -1,0 +1,24 @@
+---
+title: Subscriber
+parent: Reports
+grand_parent: Types
+---
+
+# Subscriber
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.Subscriber`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DisplayName` | `string` | read/write | — |
+| `GroupId` | `int` | read/write | — |
+
+

--- a/docs/types/reports/Summary.md
+++ b/docs/types/reports/Summary.md
@@ -1,0 +1,26 @@
+---
+title: Summary
+parent: Reports
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Reports.Summary`  
+**Namespace:** `Thycotic.PowerShell.Reports`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CategoryId` | `int` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/reports/readme.md
+++ b/docs/types/reports/readme.md
@@ -1,0 +1,11 @@
+---
+title: Reports
+parent: Types
+has_children: true
+---
+
+# Reports
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/roles/Role.md
+++ b/docs/types/roles/Role.md
@@ -1,0 +1,27 @@
+---
+title: Role
+parent: Roles
+grand_parent: Types
+---
+
+# Role
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Roles.Role`  
+**Namespace:** `Thycotic.PowerShell.Roles`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Created` | `DateTime?` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `isSystem` | `bool` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/roles/readme.md
+++ b/docs/types/roles/readme.md
@@ -1,0 +1,11 @@
+---
+title: Roles
+parent: Types
+has_children: true
+---
+
+# Roles
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/scripts/AdditionalData.md
+++ b/docs/types/scripts/AdditionalData.md
@@ -1,0 +1,27 @@
+---
+title: AdditionalData
+parent: Scripts
+grand_parent: Types
+---
+
+# AdditionalData
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Scripts.AdditionalData`  
+**Namespace:** `Thycotic.PowerShell.Scripts`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DoNotUseEnvironment` | `bool` | read/write | — |
+| `LineEnding` | `int` | read/write | — |
+| `Params` | `AdditionalDataParams[]` | read/write | — |
+| `Port` | `int` | read/write | — |
+| `Version` | `int` | read/write | — |
+
+

--- a/docs/types/scripts/AdditionalDataParams.md
+++ b/docs/types/scripts/AdditionalDataParams.md
@@ -1,0 +1,24 @@
+---
+title: AdditionalDataParams
+parent: Scripts
+grand_parent: Types
+---
+
+# AdditionalDataParams
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Scripts.AdditionalDataParams`  
+**Namespace:** `Thycotic.PowerShell.Scripts`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Name` | `string` | read/write | — |
+| `SshType` | `int` | read/write | — |
+
+

--- a/docs/types/scripts/Script.md
+++ b/docs/types/scripts/Script.md
@@ -1,0 +1,38 @@
+---
+title: Script
+parent: Scripts
+grand_parent: Types
+---
+
+# Script
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Scripts.Script`  
+**Namespace:** `Thycotic.PowerShell.Scripts`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `AdditionalData` | `AdditionalData` | read/write | — |
+| `ConcurrencyId` | `string` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `OdbcConnectionStringArgs` | `string` | read/write | — |
+| `ScriptCategoryId` | `int` | read/write | — |
+| `ScriptCategoryName` | `string` | read/write | — |
+| `ScriptContent` | `string[]` | read/write | — |
+| `ScriptId` | `int` | read/write | — |
+| `ScriptType` | `string` | read/write | — |
+| `UsageCount` | `int` | read/write | — |
+
+## Methods
+
+- `[AdditionalDataParams[]] GetScriptParams()`
+
+

--- a/docs/types/scripts/ScriptCategory.md
+++ b/docs/types/scripts/ScriptCategory.md
@@ -1,0 +1,26 @@
+---
+title: ScriptCategory
+parent: Scripts
+grand_parent: Types
+---
+
+# ScriptCategory
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.ScriptCategory`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Untyped` | `1` |
+| `TicketValidation` | `2` |
+| `TicketComment` | `3` |
+| `SecretDiscovery` | `4` |
+| `Heartbeat` | `5` |
+| `PasswordChanging` | `6` |
+| `DiscoveryTakeover` | `7` |
+| `Dependency` | `8` |
+
+

--- a/docs/types/scripts/ScriptType.md
+++ b/docs/types/scripts/ScriptType.md
@@ -1,0 +1,21 @@
+---
+title: ScriptType
+parent: Scripts
+grand_parent: Types
+---
+
+# ScriptType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.ScriptType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `PowerShell` | `1` |
+| `SQL` | `2` |
+| `SSH` | `3` |
+
+

--- a/docs/types/scripts/Summary.md
+++ b/docs/types/scripts/Summary.md
@@ -1,0 +1,30 @@
+---
+title: Summary
+parent: Scripts
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Scripts.Summary`  
+**Namespace:** `Thycotic.PowerShell.Scripts`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `ConcurrencyId` | `string` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `ScriptCategoryId` | `int` | read/write | — |
+| `ScriptCategoryName` | `string` | read/write | — |
+| `ScriptId` | `int` | read/write | — |
+| `ScriptType` | `string` | read/write | — |
+
+

--- a/docs/types/scripts/readme.md
+++ b/docs/types/scripts/readme.md
@@ -1,0 +1,11 @@
+---
+title: Scripts
+parent: Types
+has_children: true
+---
+
+# Scripts
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/secret-access-requests/Option.md
+++ b/docs/types/secret-access-requests/Option.md
@@ -1,0 +1,32 @@
+---
+title: Option
+parent: Secret Access Requests
+grand_parent: Types
+---
+
+# Option
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.AccessRequests.Option`  
+**Namespace:** `Thycotic.PowerShell.AccessRequests`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CustomCheckoutIntervalDays` | `int` | read/write | — |
+| `CustomCheckoutIntervalHours` | `int` | read/write | — |
+| `CustomCheckoutIntervalMinutes` | `int` | read/write | — |
+| `EditorsAlsoRequireApproval` | `bool` | read/write | — |
+| `EnableDoubleLock` | `bool` | read/write | — |
+| `EnableRequiresApprovalForAccess` | `bool` | read/write | — |
+| `IsDefaultCheckoutInterval` | `bool` | read/write | — |
+| `OwnersAndApproversAlsoRequireApproval` | `bool` | read/write | — |
+| `RequireCheckout` | `bool` | read/write | — |
+| `RequireCommentTicketNumber` | `bool` | read/write | — |
+
+

--- a/docs/types/secret-access-requests/Request.md
+++ b/docs/types/secret-access-requests/Request.md
@@ -1,0 +1,44 @@
+---
+title: Request
+parent: Secret Access Requests
+grand_parent: Types
+---
+
+# Request
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.AccessRequests.Request`  
+**Namespace:** `Thycotic.PowerShell.AccessRequests`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AccessRequestWorkflowMapId` | `int` | read/write | — |
+| `ApproverDisplayName` | `string` | read/write | — |
+| `Completed` | `bool` | read/write | — |
+| `CurrentUserRestrictedFromReviewing` | `bool` | read/write | — |
+| `ExpirationDate` | `DateTime?` | read/write | — |
+| `FolderId` | `int` | read/write | — |
+| `HasWorkflow` | `bool` | read/write | — |
+| `RequestComment` | `string` | read/write | — |
+| `RequestDate` | `DateTime?` | read/write | — |
+| `RequestingUserId` | `int` | read/write | — |
+| `RequestUsername` | `string` | read/write | — |
+| `ResponseComment` | `string` | read/write | — |
+| `ResponseDate` | `DateTime?` | read/write | — |
+| `ReviewStatusMessage` | `string` | read/write | — |
+| `SecretAccessRequestId` | `int` | read/write | — |
+| `SecretId` | `int` | read/write | — |
+| `SecretName` | `string` | read/write | — |
+| `StartDate` | `DateTime?` | read/write | — |
+| `Status` | `string` | read/write | — |
+| `StatusDescription` | `string` | read/write | — |
+| `TicketNumber` | `string` | read/write | — |
+| `TicketSystemId` | `int` | read/write | — |
+
+

--- a/docs/types/secret-access-requests/SecretAccessStatus.md
+++ b/docs/types/secret-access-requests/SecretAccessStatus.md
@@ -1,0 +1,22 @@
+---
+title: SecretAccessStatus
+parent: Secret Access Requests
+grand_parent: Types
+---
+
+# SecretAccessStatus
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretAccessStatus`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Approved` | _(default)_ |
+| `Canceled` | _(default)_ |
+| `Denied` | _(default)_ |
+| `Pending` | _(default)_ |
+
+

--- a/docs/types/secret-access-requests/readme.md
+++ b/docs/types/secret-access-requests/readme.md
@@ -1,0 +1,11 @@
+---
+title: Secret Access Requests
+parent: Types
+has_children: true
+---
+
+# Secret Access Requests
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/secret-dependencies/Dependency.md
+++ b/docs/types/secret-dependencies/Dependency.md
@@ -1,0 +1,42 @@
+---
+title: Dependency
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# Dependency
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.Dependency`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `ChildDependencyStatus` | `bool` | read/write | — |
+| `ConditionDependencyId` | `int` | read/write | — |
+| `ConditionMode` | `string` | read/write | — |
+| `DependencyTemplate` | `DependencyTemplate` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `GroupId` | `int` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `LogMessage` | `string` | read/write | — |
+| `PrivilegedAccountSecretId` | `int` | read/write | — |
+| `RunScript` | `RunScript` | read/write | — |
+| `SecretDependencyStatus` | `bool` | read/write | — |
+| `SecretId` | `int` | read/write | — |
+| `SecretName` | `string` | read/write | — |
+| `Settings` | `DependencySetting[]` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+| `SshKeySecretId` | `int` | read/write | — |
+| `SshKeySecretName` | `string` | read/write | — |
+| `TypeId` | `int` | read/write | — |
+| `TypeName` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/DependencySetting.md
+++ b/docs/types/secret-dependencies/DependencySetting.md
@@ -1,0 +1,27 @@
+---
+title: DependencySetting
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# DependencySetting
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.DependencySetting`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `changerSettingValue` | `string` | read/write | — |
+| `Setting` | `Setting` | read/write | — |
+| `settingId` | `int` | read/write | — |
+| `SettingName` | `string` | read/write | — |
+| `SettingValue` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/DependencyTemplate.md
+++ b/docs/types/secret-dependencies/DependencyTemplate.md
@@ -1,0 +1,27 @@
+---
+title: DependencyTemplate
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# DependencyTemplate
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.DependencyTemplate`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ChangerScriptId` | `int` | read/write | — |
+| `DependencyScanItemFields` | `ScanItemFields[]` | read/write | — |
+| `ScriptName` | `string` | read/write | — |
+| `SecretDependencyChangerId` | `int` | read/write | — |
+| `SecretDependencyTemplateId` | `int` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/Group.md
+++ b/docs/types/secret-dependencies/Group.md
@@ -1,0 +1,30 @@
+---
+title: Group
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# Group
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.Group`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `SiteId` | `int` | read/write | — |
+| `SiteName` | `string` | read/write | — |
+| `StatusFailedCount` | `int` | read/write | — |
+| `StatusNotRunCount` | `int` | read/write | — |
+| `StatusSuccessCount` | `int` | read/write | — |
+| `TotalDependencies` | `int` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/OdbcConnectionArgument.md
+++ b/docs/types/secret-dependencies/OdbcConnectionArgument.md
@@ -1,0 +1,24 @@
+---
+title: OdbcConnectionArgument
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# OdbcConnectionArgument
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.OdbcConnectionArgument`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Name` | `string` | read/write | — |
+| `Value` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/RunScript.md
+++ b/docs/types/secret-dependencies/RunScript.md
@@ -1,0 +1,28 @@
+---
+title: RunScript
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# RunScript
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.RunScript`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `MachineName` | `string` | read/write | — |
+| `OdbcConnectionArguments` | `object[]` | read/write | — |
+| `ScriptArguments` | `object[]` | read/write | — |
+| `ScriptId` | `int` | read/write | — |
+| `ScriptName` | `string` | read/write | — |
+| `ServiceName` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/ScanItemFields.md
+++ b/docs/types/secret-dependencies/ScanItemFields.md
@@ -1,0 +1,26 @@
+---
+title: ScanItemFields
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# ScanItemFields
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.ScanItemFields`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `ParentName` | `string` | read/write | — |
+| `Value` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/Script.md
+++ b/docs/types/secret-dependencies/Script.md
@@ -1,0 +1,26 @@
+---
+title: Script
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# Script
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.Script`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Arguments` | `ScriptArgument[]` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `OdbcConnectionArguments` | `OdbcConnectionArgument[]` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/ScriptArgument.md
+++ b/docs/types/secret-dependencies/ScriptArgument.md
@@ -1,0 +1,25 @@
+---
+title: ScriptArgument
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# ScriptArgument
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.ScriptArgument`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Name` | `string` | read/write | — |
+| `Type` | `string` | read/write | — |
+| `Value` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/Setting.md
+++ b/docs/types/secret-dependencies/Setting.md
@@ -1,0 +1,36 @@
+---
+title: Setting
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# Setting
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.Setting`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `CanEdit` | `bool` | read/write | — |
+| `CanEditValue` | `bool` | read/write | — |
+| `ChildSettings` | `Setting[]` | read/write | — |
+| `DefaultValue` | `string` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `isVisibile` | `bool` | read/write | — |
+| `ParentSettingId` | `int` | read/write | — |
+| `RegexValidation` | `string` | read/write | — |
+| `SettingName` | `string` | read/write | — |
+| `SettingSectionId` | `int` | read/write | — |
+| `SettingType` | `int` | read/write | — |
+| `SubSettingSectionId` | `int` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/Summary.md
+++ b/docs/types/secret-dependencies/Summary.md
@@ -1,0 +1,33 @@
+---
+title: Summary
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.Summary`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `canTest` | `bool` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `GroupId` | `int` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `MachineName` | `string` | read/write | — |
+| `Order` | `int` | read/write | — |
+| `RunResult` | `string` | read/write | — |
+| `SecretId` | `int` | read/write | — |
+| `ServiceName` | `string` | read/write | — |
+| `TypeId` | `int` | read/write | — |
+| `TypeName` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/TaskError.md
+++ b/docs/types/secret-dependencies/TaskError.md
@@ -1,0 +1,24 @@
+---
+title: TaskError
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# TaskError
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.TaskError`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ErrorMessage` | `string` | read/write | — |
+| `ItemName` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/TaskProgress.md
+++ b/docs/types/secret-dependencies/TaskProgress.md
@@ -1,0 +1,27 @@
+---
+title: TaskProgress
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# TaskProgress
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.TaskProgress`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Errors` | `TaskError[]` | read/write | — |
+| `IsComplete` | `bool` | read/write | — |
+| `PercentageComplete` | `int` | read/write | — |
+| `Status` | `string` | read/write | — |
+| `TaskIdentifier` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/Template.md
+++ b/docs/types/secret-dependencies/Template.md
@@ -1,0 +1,27 @@
+---
+title: Template
+parent: Secret Dependencies
+grand_parent: Types
+---
+
+# Template
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretDependencies.Template`  
+**Namespace:** `Thycotic.PowerShell.SecretDependencies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `DependencyChangerId` | `int` | read/write | — |
+| `DependencyTypeId` | `int` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/secret-dependencies/readme.md
+++ b/docs/types/secret-dependencies/readme.md
@@ -1,0 +1,11 @@
+---
+title: Secret Dependencies
+parent: Types
+has_children: true
+---
+
+# Secret Dependencies
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/secret-extensions/Secret.md
+++ b/docs/types/secret-extensions/Secret.md
@@ -1,0 +1,35 @@
+---
+title: Secret
+parent: Secret Extensions
+grand_parent: Types
+---
+
+# Secret
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretExtensions.Secret`  
+**Namespace:** `Thycotic.PowerShell.SecretExtensions`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `HasOwnerOrEditAccess` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `IsButtonBound` | `bool` | read/write | — |
+| `IsFavoriteSecret` | `bool` | read/write | — |
+| `IsSystemFolder` | `bool` | read/write | — |
+| `MatchOrderType` | `SecretMatchType` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `RedirectUrl` | `string` | read/write | — |
+| `RequireComment` | `bool` | read/write | — |
+| `ResultPriority` | `int` | read/write | — |
+| `SecretTypeId` | `int` | read/write | — |
+| `SecretUrl` | `string` | read/write | — |
+| `ShouldRedirect` | `bool` | read/write | — |
+
+

--- a/docs/types/secret-extensions/SecretMatchType.md
+++ b/docs/types/secret-extensions/SecretMatchType.md
@@ -1,0 +1,21 @@
+---
+title: SecretMatchType
+parent: Secret Extensions
+grand_parent: Types
+---
+
+# SecretMatchType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretMatchType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Loose` | _(default)_ |
+| `Partial` | _(default)_ |
+| `Exact` | _(default)_ |
+
+

--- a/docs/types/secret-extensions/readme.md
+++ b/docs/types/secret-extensions/readme.md
@@ -1,0 +1,11 @@
+---
+title: Secret Extensions
+parent: Types
+has_children: true
+---
+
+# Secret Extensions
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/secret-hooks/Hook.md
+++ b/docs/types/secret-hooks/Hook.md
@@ -1,0 +1,46 @@
+---
+title: Hook
+parent: Secret Hooks
+grand_parent: Types
+---
+
+# Hook
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretHooks.Hook`  
+**Namespace:** `Thycotic.PowerShell.SecretHooks`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Arguments` | `string` | read/write | — |
+| `Database` | `string` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `EventActionId` | `int` | read/write | — |
+| `FailureMessage` | `string` | read/write | — |
+| `HookId` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `Parameters` | `Parameter[]` | read/write | — |
+| `Port` | `int` | read/write | — |
+| `PrePostOption` | `string` | read/write | — |
+| `PrivilegeSecretId` | `int` | read/write | — |
+| `ScriptId` | `int` | read/write | — |
+| `ScriptTypeId` | `int` | read/write | — |
+| `SecretHookId` | `int` | read/write | — |
+| `ServerKeyDigest` | `string` | read/write | — |
+| `ServerName` | `string` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+| `SshKeySecretId` | `int` | read/write | — |
+| `Status` | `bool` | read/write | — |
+| `StopOnFailure` | `bool` | read/write | — |
+
+## Methods
+
+- `[void] SetHookParameter(string Name, string Value)`
+
+

--- a/docs/types/secret-hooks/Parameter.md
+++ b/docs/types/secret-hooks/Parameter.md
@@ -1,0 +1,25 @@
+---
+title: Parameter
+parent: Secret Hooks
+grand_parent: Types
+---
+
+# Parameter
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretHooks.Parameter`  
+**Namespace:** `Thycotic.PowerShell.SecretHooks`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ParameterName` | `string` | read/write | — |
+| `ParameterType` | `string` | read/write | `"Literal"` |
+| `ParameterValue` | `string` | read/write | — |
+
+

--- a/docs/types/secret-hooks/Summary.md
+++ b/docs/types/secret-hooks/Summary.md
@@ -1,0 +1,34 @@
+---
+title: Summary
+parent: Secret Hooks
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretHooks.Summary`  
+**Namespace:** `Thycotic.PowerShell.SecretHooks`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Description` | `string` | read/write | — |
+| `EventActionName` | `string` | read/write | — |
+| `HookId` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `PrePostOption` | `string` | read/write | — |
+| `scriptID` | `int` | read/write | — |
+| `ScriptName` | `string` | read/write | — |
+| `ScriptTypeName` | `string` | read/write | — |
+| `SecretHookId` | `int` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+| `Status` | `bool` | read/write | — |
+| `StopOnFailure` | `bool` | read/write | — |
+
+

--- a/docs/types/secret-hooks/readme.md
+++ b/docs/types/secret-hooks/readme.md
@@ -1,0 +1,11 @@
+---
+title: Secret Hooks
+parent: Types
+has_children: true
+---
+
+# Secret Hooks
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/secret-permissions/Permission.md
+++ b/docs/types/secret-permissions/Permission.md
@@ -1,0 +1,32 @@
+---
+title: Permission
+parent: Secret Permissions
+grand_parent: Types
+---
+
+# Permission
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretPermissions.Permission`  
+**Namespace:** `Thycotic.PowerShell.SecretPermissions`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DomainName` | `string` | read/write | — |
+| `GroupId` | `int` | read/write | — |
+| `GroupName` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `KnownAs` | `string` | read/write | — |
+| `SecretAccessRoleId` | `int` | read/write | — |
+| `SecretAccessRoleName` | `string` | read/write | — |
+| `SecretId` | `int` | read/write | — |
+| `UserId` | `int` | read/write | — |
+| `Username` | `string` | read/write | — |
+
+

--- a/docs/types/secret-permissions/readme.md
+++ b/docs/types/secret-permissions/readme.md
@@ -1,0 +1,11 @@
+---
+title: Secret Permissions
+parent: Types
+has_children: true
+---
+
+# Secret Permissions
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/secret-policies/Policy.md
+++ b/docs/types/secret-policies/Policy.md
@@ -1,0 +1,27 @@
+---
+title: Policy
+parent: Secret Policies
+grand_parent: Types
+---
+
+# Policy
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretPolicies.Policy`  
+**Namespace:** `Thycotic.PowerShell.SecretPolicies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `SecretPolicyDescription` | `string` | read/write | — |
+| `SecretPolicyId` | `int` | read/write | — |
+| `SecretPolicyItems` | `PolicyItem[]` | read/write | — |
+| `SecretPolicyName` | `string` | read/write | — |
+
+

--- a/docs/types/secret-policies/PolicyItem.md
+++ b/docs/types/secret-policies/PolicyItem.md
@@ -1,0 +1,36 @@
+---
+title: PolicyItem
+parent: Secret Policies
+grand_parent: Types
+---
+
+# PolicyItem
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretPolicies.PolicyItem`  
+**Namespace:** `Thycotic.PowerShell.SecretPolicies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Description` | `string` | read/write | — |
+| `Name` | `SecretPolicyItem` | read/write | — |
+| `ParentSecretPolicyItemId` | `int` | read/write | — |
+| `PolicyApplyType` | `SecretPolicyApplyType` | read/write | — |
+| `SecretPolicyItemId` | `int` | read/write | — |
+| `SecretPolicyItemMapId` | `int` | read/write | — |
+| `SectionName` | `string` | read/write | — |
+| `SshCommandMenuGroupMaps` | `SshCommandMenuGroupMap[]` | read/write | — |
+| `UserGroupMaps` | `UserGroupMap[]` | read/write | — |
+| `ValueBool` | `bool` | read/write | — |
+| `ValueInt` | `int` | read/write | — |
+| `ValueSecretId` | `int` | read/write | — |
+| `ValueString` | `string` | read/write | — |
+| `ValueType` | `SecretPolicyValueType` | read/write | — |
+
+

--- a/docs/types/secret-policies/SecretPolicyApplyType.md
+++ b/docs/types/secret-policies/SecretPolicyApplyType.md
@@ -1,0 +1,21 @@
+---
+title: SecretPolicyApplyType
+parent: Secret Policies
+grand_parent: Types
+---
+
+# SecretPolicyApplyType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretPolicyApplyType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `NotSet` | _(default)_ |
+| `Default` | _(default)_ |
+| `Enforced` | _(default)_ |
+
+

--- a/docs/types/secret-policies/SecretPolicyItem.md
+++ b/docs/types/secret-policies/SecretPolicyItem.md
@@ -1,0 +1,49 @@
+---
+title: SecretPolicyItem
+parent: Secret Policies
+grand_parent: Types
+---
+
+# SecretPolicyItem
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretPolicyItem`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `AutoChangeOnExpiration` | `1` |
+| `HeartBeatEnabled` | `2` |
+| `SiteId` | `3` |
+| `PrivilegedSecretId` | `4` |
+| `PriveledgedSecretId` | `4` |
+| `AssociatedSecretId1` | `5` |
+| `AutoChangeSchedule` | `6` |
+| `PasswordTypeWebScriptId` | `7` |
+| `CheckOutEnabled` | `8` |
+| `CheckOutIntervalMinutes` | `9` |
+| `CheckOutChangePassword` | `10` |
+| `RequireApprovalForAccess` | `11` |
+| `RequireApprovalForAccessForOwnersAndApprovers` | `12` |
+| `RequireApprovalForAccessForEditors` | `13` |
+| `RequireViewComment` | `14` |
+| `IsSessionRecordingEnabled` | `15` |
+| `ViewingPasswordRequiresEdit` | `16` |
+| `ApprovalGroup` | `17` |
+| `AssociatedSecretId2` | `18` |
+| `IsProxyEnabled` | `19` |
+| `EnableSshCommandRestrictions` | `20` |
+| `SshCommandMenuGroups` | `21` |
+| `AllowOwnersUnrestrictedSshCommands` | `22` |
+| `ApprovalWorkflow` | `23` |
+| `EventPipelinePolicy` | `24` |
+| `RunLauncherUsingSSHKey` | `25` |
+| `WebLauncherRequiresIncognitoMode` | `26` |
+| `SshCommandRestrictionType` | `27` |
+| `SshCommandBlocklistOwners` | `28` |
+| `SshCommandBlocklistEditors` | `29` |
+| `SshCommandBlocklistViewers` | `30` |
+
+

--- a/docs/types/secret-policies/SecretPolicyValueType.md
+++ b/docs/types/secret-policies/SecretPolicyValueType.md
@@ -1,0 +1,25 @@
+---
+title: SecretPolicyValueType
+parent: Secret Policies
+grand_parent: Types
+---
+
+# SecretPolicyValueType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretPolicyValueType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Bool` | _(default)_ |
+| `Int` | _(default)_ |
+| `SecretId` | _(default)_ |
+| `Group` | _(default)_ |
+| `Schedule` | _(default)_ |
+| `SshMenuGroup` | _(default)_ |
+| `SshBlocklist` | _(default)_ |
+
+

--- a/docs/types/secret-policies/SshCommandMenuGroupMap.md
+++ b/docs/types/secret-policies/SshCommandMenuGroupMap.md
@@ -1,0 +1,24 @@
+---
+title: SshCommandMenuGroupMap
+parent: Secret Policies
+grand_parent: Types
+---
+
+# SshCommandMenuGroupMap
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretPolicies.SshCommandMenuGroupMap`  
+**Namespace:** `Thycotic.PowerShell.SecretPolicies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `GroupId` | `int` | read/write | — |
+| `SshCommandMenuId` | `int` | read/write | — |
+
+

--- a/docs/types/secret-policies/Summary.md
+++ b/docs/types/secret-policies/Summary.md
@@ -1,0 +1,26 @@
+---
+title: Summary
+parent: Secret Policies
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretPolicies.Summary`  
+**Namespace:** `Thycotic.PowerShell.SecretPolicies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `SecretPolicyDescription` | `string` | read/write | — |
+| `SecretPolicyId` | `int` | read/write | — |
+| `SecretPolicyName` | `string` | read/write | — |
+
+

--- a/docs/types/secret-policies/UserGroupMap.md
+++ b/docs/types/secret-policies/UserGroupMap.md
@@ -1,0 +1,23 @@
+---
+title: UserGroupMap
+parent: Secret Policies
+grand_parent: Types
+---
+
+# UserGroupMap
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretPolicies.UserGroupMap`  
+**Namespace:** `Thycotic.PowerShell.SecretPolicies`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `GroupId` | `int` | read/write | — |
+
+

--- a/docs/types/secret-policies/readme.md
+++ b/docs/types/secret-policies/readme.md
@@ -1,0 +1,11 @@
+---
+title: Secret Policies
+parent: Types
+has_children: true
+---
+
+# Secret Policies
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/secret-templates/Field.md
+++ b/docs/types/secret-templates/Field.md
@@ -1,0 +1,46 @@
+---
+title: Field
+parent: Secret Templates
+grand_parent: Types
+---
+
+# Field
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretTemplates.Field`  
+**Namespace:** `Thycotic.PowerShell.SecretTemplates`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Description` | `string` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `EditablePermission` | `int` | read/write | — |
+| `EditRequires` | `TemplateEditRequiresOptions` | read/write | — |
+| `FieldSlugName` | `string` | read/write | — |
+| `GeneratePasswordCharacterSet` | `string` | read/write | — |
+| `GeneratePasswordLength` | `int` | read/write | — |
+| `HideOnView` | `bool` | read/write | — |
+| `HistoryLength` | `int` | read/write | — |
+| `IsExpirationField` | `bool` | read/write | — |
+| `IsFile` | `bool` | read/write | — |
+| `IsIndexable` | `bool` | read/write | — |
+| `IsList` | `bool` | read/write | — |
+| `IsNotes` | `bool` | read/write | — |
+| `IsPassword` | `bool` | read/write | — |
+| `IsRequired` | `bool` | read/write | — |
+| `IsUrl` | `bool` | read/write | — |
+| `ListType` | `TemplateFieldListType` | read/write | — |
+| `MustEncrypt` | `bool` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `PasswordRequirementId` | `int` | read/write | — |
+| `PasswordTypeFieldId` | `int` | read/write | — |
+| `SecretTemplateFieldId` | `int` | read/write | — |
+| `SortOrder` | `int` | read/write | — |
+
+

--- a/docs/types/secret-templates/Summary.md
+++ b/docs/types/secret-templates/Summary.md
@@ -1,0 +1,29 @@
+---
+title: Summary
+parent: Secret Templates
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretTemplates.Summary`  
+**Namespace:** `Thycotic.PowerShell.SecretTemplates`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `heartbeatEnabled` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `PasswordTypeId` | `int` | read/write | — |
+| `passwordTypeReady` | `bool` | read/write | — |
+| `SecretCount` | `int` | read/write | — |
+
+

--- a/docs/types/secret-templates/Template.md
+++ b/docs/types/secret-templates/Template.md
@@ -1,0 +1,31 @@
+---
+title: Template
+parent: Secret Templates
+grand_parent: Types
+---
+
+# Template
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretTemplates.Template`  
+**Namespace:** `Thycotic.PowerShell.SecretTemplates`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Fields` | `Field[]` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `PasswordTypeId` | `int` | read/write | — |
+
+## Methods
+
+- `[Field] GetField(string SlugName)`
+- `[string] GetSlugName(string FieldName)`
+
+

--- a/docs/types/secret-templates/TemplateEditRequiresOptions.md
+++ b/docs/types/secret-templates/TemplateEditRequiresOptions.md
@@ -1,0 +1,21 @@
+---
+title: TemplateEditRequiresOptions
+parent: Secret Templates
+grand_parent: Types
+---
+
+# TemplateEditRequiresOptions
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.TemplateEditRequiresOptions`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Edit` | _(default)_ |
+| `Owner` | _(default)_ |
+| `NotEditable` | _(default)_ |
+
+

--- a/docs/types/secret-templates/TemplateFieldListType.md
+++ b/docs/types/secret-templates/TemplateFieldListType.md
@@ -1,0 +1,21 @@
+---
+title: TemplateFieldListType
+parent: Secret Templates
+grand_parent: Types
+---
+
+# TemplateFieldListType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.TemplateFieldListType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `None` | _(default)_ |
+| `Generic` | _(default)_ |
+| `URL` | _(default)_ |
+
+

--- a/docs/types/secret-templates/TemplateFieldTypes.md
+++ b/docs/types/secret-templates/TemplateFieldTypes.md
@@ -1,0 +1,23 @@
+---
+title: TemplateFieldTypes
+parent: Secret Templates
+grand_parent: Types
+---
+
+# TemplateFieldTypes
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.TemplateFieldTypes`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Notes` | _(default)_ |
+| `Text` | _(default)_ |
+| `File` | _(default)_ |
+| `Url` | _(default)_ |
+| `Password` | _(default)_ |
+
+

--- a/docs/types/secret-templates/View.md
+++ b/docs/types/secret-templates/View.md
@@ -1,0 +1,24 @@
+---
+title: View
+parent: Secret Templates
+grand_parent: Types
+---
+
+# View
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.SecretTemplates.View`  
+**Namespace:** `Thycotic.PowerShell.SecretTemplates`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Id` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/secret-templates/readme.md
+++ b/docs/types/secret-templates/readme.md
@@ -1,0 +1,11 @@
+---
+title: Secret Templates
+parent: Types
+has_children: true
+---
+
+# Secret Templates
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/secrets/Audit.md
+++ b/docs/types/secrets/Audit.md
@@ -1,0 +1,36 @@
+---
+title: Audit
+parent: Secrets
+grand_parent: Types
+---
+
+# Audit
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.Audit`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Action` | `string` | read/write | — |
+| `ActionForDisplay` | `string` | read/write | — |
+| `ByUserDisplayName` | `string` | read/write | — |
+| `DatabaseName` | `string` | read/write | — |
+| `DateRecorded` | `DateTime?` | read/write | — |
+| `HasProxySessionData` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Notes` | `string` | read/write | — |
+| `RecordingMessage` | `string` | read/write | — |
+| `RecordingSessionId` | `string` | read/write | — |
+| `RecordingStatus` | `int` | read/write | — |
+| `Status` | `string` | read/write | — |
+| `TicketNumber` | `string` | read/write | — |
+| `Username` | `string` | read/write | — |
+
+

--- a/docs/types/secrets/DetailSettings.md
+++ b/docs/types/secrets/DetailSettings.md
@@ -1,0 +1,32 @@
+---
+title: DetailSettings
+parent: Secrets
+grand_parent: Types
+---
+
+# DetailSettings
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.DetailSettings`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `ExpirationDate` | `DateTime?` | read/write | — |
+| `ExpirationDayInterval` | `int` | read/write | — |
+| `ExpirationTemplateText` | `string` | read/write | — |
+| `ExpirationType` | `string` | read/write | — |
+| `OneTimePasswordSettings` | `OneTimePasswordSettings` | read/write | — |
+| `RdpLauncherSettings` | `RdpLauncherSettings` | read/write | — |
+| `SendEmailWhenChanged` | `bool` | read/write | — |
+| `SendEmailWhenHeartbeatFails` | `bool` | read/write | — |
+| `SendEmailWhenViewed` | `bool` | read/write | — |
+| `SshLauncherSettings` | `SshLauncherSettings` | read/write | — |
+
+

--- a/docs/types/secrets/DetailState.md
+++ b/docs/types/secrets/DetailState.md
@@ -1,0 +1,42 @@
+---
+title: DetailState
+parent: Secrets
+grand_parent: Types
+---
+
+# DetailState
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.DetailState`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Actions` | `string[]` | read/write | — |
+| `CheckedOutUserDisplayname` | `string` | read/write | — |
+| `CheckedOutUserId` | `int` | read/write | — |
+| `CheckOutIntervalMinutes` | `int` | read/write | — |
+| `CheckOutMinutesRemaining` | `int` | read/write | — |
+| `FolderId` | `int` | read/write | — |
+| `FolderName` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `IsActive` | `bool` | read/write | — |
+| `IsCheckedOut` | `bool` | read/write | — |
+| `IsCheckedOutByCurrentUser` | `bool` | read/write | — |
+| `PasswordChangePending` | `bool` | read/write | — |
+| `Role` | `string` | read/write | — |
+| `SecretName` | `string` | read/write | — |
+| `SecretState` | `SecretStates` | read/write | — |
+
+## Methods
+
+- `[bool] TestAction(string ActionName)`
+- `[bool] TestState(string State)`
+
+

--- a/docs/types/secrets/HeartbeatStatus.md
+++ b/docs/types/secrets/HeartbeatStatus.md
@@ -1,0 +1,24 @@
+---
+title: HeartbeatStatus
+parent: Secrets
+grand_parent: Types
+---
+
+# HeartbeatStatus
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.HeartbeatStatus`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `LastHeartbeatCheck` | `DateTime?` | read/write | — |
+| `Status` | `SecretHeartbeatStatus` | read/write | — |
+
+

--- a/docs/types/secrets/Items.md
+++ b/docs/types/secrets/Items.md
@@ -1,0 +1,35 @@
+---
+title: Items
+parent: Secrets
+grand_parent: Types
+---
+
+# Items
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.Items`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `FieldDescription` | `string` | read/write | — |
+| `FieldId` | `int` | read/write | — |
+| `FieldName` | `string` | read/write | — |
+| `FileAttachmentId` | `int` | read/write | — |
+| `Filename` | `string` | read/write | — |
+| `IsFile` | `bool` | read/write | — |
+| `IsList` | `bool` | read/write | — |
+| `IsNotes` | `bool` | read/write | — |
+| `IsPassword` | `bool` | read/write | — |
+| `ItemId` | `int` | read/write | — |
+| `ItemValue` | `string` | read/write | — |
+| `ListType` | `string` | read/write | — |
+| `Slug` | `string` | read/write | — |
+
+

--- a/docs/types/secrets/Lookup.md
+++ b/docs/types/secrets/Lookup.md
@@ -1,0 +1,26 @@
+---
+title: Lookup
+parent: Secrets
+grand_parent: Types
+---
+
+# Lookup
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.Lookup`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `FolderId` | `int` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `SecretName` | `string` | read/write | — |
+| `SecretTemplateId` | `int` | read/write | — |
+
+

--- a/docs/types/secrets/OneTimePasswordSettings.md
+++ b/docs/types/secrets/OneTimePasswordSettings.md
@@ -1,0 +1,27 @@
+---
+title: OneTimePasswordSettings
+parent: Secrets
+grand_parent: Types
+---
+
+# OneTimePasswordSettings
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.OneTimePasswordSettings`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `BackupCodes` | `string` | read/write | — |
+| `DateChanged` | `DateTime?` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `EnabledOnTemplate` | `bool` | read/write | — |
+| `Key` | `string` | read/write | — |
+
+

--- a/docs/types/secrets/PasswordStatus.md
+++ b/docs/types/secrets/PasswordStatus.md
@@ -1,0 +1,27 @@
+---
+title: PasswordStatus
+parent: Secrets
+grand_parent: Types
+---
+
+# PasswordStatus
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.PasswordStatus`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `FailedAttempts` | `int` | read/write | — |
+| `LastRpcDate` | `DateTime?` | read/write | — |
+| `NextRpcDate` | `DateTime?` | read/write | — |
+| `RpcMessage` | `string` | read/write | — |
+| `Status` | `string` | read/write | — |
+
+

--- a/docs/types/secrets/RdpLauncherSettings.md
+++ b/docs/types/secrets/RdpLauncherSettings.md
@@ -1,0 +1,30 @@
+---
+title: RdpLauncherSettings
+parent: Secrets
+grand_parent: Types
+---
+
+# RdpLauncherSettings
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.RdpLauncherSettings`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AllowClipboard` | `string` | read/write | — |
+| `AllowDrives` | `string` | read/write | — |
+| `AllowPrinters` | `string` | read/write | — |
+| `AllowSmartCards` | `string` | read/write | — |
+| `ConnectToConsole` | `string` | read/write | — |
+| `LauncherHeight` | `int` | read/write | — |
+| `LauncherWidth` | `int` | read/write | — |
+| `UseCustomLauncherResolution` | `string` | read/write | — |
+
+

--- a/docs/types/secrets/Secret.md
+++ b/docs/types/secrets/Secret.md
@@ -1,0 +1,74 @@
+---
+title: Secret
+parent: Secrets
+grand_parent: Types
+---
+
+# Secret
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.Secret`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AccessRequestWorkflowMapId` | `int` | read/write | — |
+| `Active` | `bool` | read/write | — |
+| `AllowOwnersUnrestrictedSshCommands` | `bool` | read/write | — |
+| `AutoChangeEnabled` | `bool` | read/write | — |
+| `AutoChangeNextPassword` | `string` | read/write | — |
+| `CheckedOut` | `bool` | read/write | — |
+| `CheckOutChangePasswordEnabled` | `bool` | read/write | — |
+| `CheckOutEnabled` | `bool` | read/write | — |
+| `CheckOutIntervalMinutes` | `int` | read/write | — |
+| `CheckOutMinutesRemaining` | `int` | read/write | — |
+| `CheckOutUserDisplayName` | `string` | read/write | — |
+| `CheckOutUserId` | `int` | read/write | — |
+| `DoubleLockId` | `int` | read/write | — |
+| `EnableInheritPermissions` | `bool` | read/write | — |
+| `EnableInheritSecretPolicy` | `bool` | read/write | — |
+| `FailedPasswordChangeAttempts` | `int` | read/write | — |
+| `Filename` | `string` | read/write | — |
+| `FolderId` | `int` | read/write | — |
+| `hsmKeyIdentifier` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `IsDoubleLock` | `bool` | read/write | — |
+| `IsOutOfSync` | `bool` | read/write | — |
+| `IsRestricted` | `bool` | read/write | — |
+| `Items` | `Items[]` | read/write | — |
+| `JumpboxRouteId` | `int?` | read/write | — |
+| `LastHeartBeatCheck` | `DateTime?` | read/write | — |
+| `LastHeartBeatStatus` | `SecretHeartbeatStatus` | read/write | — |
+| `LastPasswordChangeAttempt` | `DateTime?` | read/write | — |
+| `LauncherConnectAsSecretId` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `OutOfSyncReason` | `string` | read/write | — |
+| `PasswordTypeWebScriptId` | `int` | read/write | — |
+| `ProxyEnabled` | `bool` | read/write | — |
+| `RequiresApprovalForAccess` | `bool` | read/write | — |
+| `RequiresComment` | `bool` | read/write | — |
+| `ResponseCodes` | `string[]` | read/write | — |
+| `RestrictSshCommands` | `bool` | read/write | — |
+| `SecretPolicyId` | `int` | read/write | — |
+| `SecretTemplateId` | `int` | read/write | — |
+| `SecretTemplateName` | `string` | read/write | — |
+| `SessionRecordingEnabled` | `bool` | read/write | — |
+| `SiteId` | `int` | read/write | — |
+| `SlugName` | `string` | read/write | — |
+| `WebLauncherRequiresIncognitoMode` | `bool` | read/write | — |
+
+## Methods
+
+- `[PSCredential] GetCredential(string DomainField, string UserField, string PasswordField)`
+- `[string] GetFieldValue(string SlugName)`
+- `[List<FileField>] GetFileFields()`
+- `[void] SetFieldValue(string SlugName, string NewValue)`
+- `[void] UpdateFieldId(string SlugName, int OrginalId, int NewId)`
+
+

--- a/docs/types/secrets/SecretActions.md
+++ b/docs/types/secrets/SecretActions.md
@@ -1,0 +1,52 @@
+---
+title: SecretActions
+parent: Secrets
+grand_parent: Types
+---
+
+# SecretActions
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretActions`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `ChangePasswordNow` | _(default)_ |
+| `ConvertTemplate` | _(default)_ |
+| `Copy` | _(default)_ |
+| `Delete` | _(default)_ |
+| `Edit` | _(default)_ |
+| `EditExpiration` | _(default)_ |
+| `EditRpc` | _(default)_ |
+| `EditSecurity` | _(default)_ |
+| `Expire` | _(default)_ |
+| `Heartbeat` | _(default)_ |
+| `EditShare` | _(default)_ |
+| `ShowSshProxyCredentials` | _(default)_ |
+| `StopChangePasswordNow` | _(default)_ |
+| `ViewAudit` | _(default)_ |
+| `ViewDependencies` | _(default)_ |
+| `ViewLaunchers` | _(default)_ |
+| `ViewExpiration` | _(default)_ |
+| `ViewHooks` | _(default)_ |
+| `ViewRpc` | _(default)_ |
+| `ViewSecurity` | _(default)_ |
+| `ViewSettings` | _(default)_ |
+| `Undelete` | _(default)_ |
+| `ForceCheckIn` | _(default)_ |
+| `ViewShare` | _(default)_ |
+| `EditHooks` | _(default)_ |
+| `EditDependencies` | _(default)_ |
+| `ViewGeneralDetails` | _(default)_ |
+| `ViewHeartbeatStatus` | _(default)_ |
+| `CheckIn` | _(default)_ |
+| `Checkout` | _(default)_ |
+| `GenerateOneTimePassword` | _(default)_ |
+| `ShowSshTerminalDetails` | _(default)_ |
+| `ShowRdpProxyCredentials` | _(default)_ |
+| `ViewMetadata` | _(default)_ |
+
+

--- a/docs/types/secrets/SecretHeartbeatStatus.md
+++ b/docs/types/secrets/SecretHeartbeatStatus.md
@@ -1,0 +1,31 @@
+---
+title: SecretHeartbeatStatus
+parent: Secrets
+grand_parent: Types
+---
+
+# SecretHeartbeatStatus
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretHeartbeatStatus`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Failed` | `0` |
+| `Success` | `1` |
+| `Pending` | `2` |
+| `Disabled` | `3` |
+| `UnableToConnect` | `4` |
+| `UnknownError` | `5` |
+| `IncompatibleHost` | `6` |
+| `AccountLockedOut` | `7` |
+| `DnsMismatch` | `8` |
+| `UnableToValidateServerPublicKey` | `9` |
+| `Processing` | `10` |
+| `ArgumentError` | `11` |
+| `AccessDenied` | `12` |
+
+

--- a/docs/types/secrets/SecretPermissions.md
+++ b/docs/types/secrets/SecretPermissions.md
@@ -1,0 +1,22 @@
+---
+title: SecretPermissions
+parent: Secrets
+grand_parent: Types
+---
+
+# SecretPermissions
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretPermissions`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `List` | `1` |
+| `View` | `2` |
+| `Edit` | `3` |
+| `Owner` | `4` |
+
+

--- a/docs/types/secrets/SecretStates.md
+++ b/docs/types/secrets/SecretStates.md
@@ -1,0 +1,29 @@
+---
+title: SecretStates
+parent: Secrets
+grand_parent: Types
+---
+
+# SecretStates
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.SecretStates`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `None` | _(default)_ |
+| `RequiresApproval` | _(default)_ |
+| `RequiresCheckout` | _(default)_ |
+| `RequiresComment` | _(default)_ |
+| `RequiresDoubleLockPassword` | _(default)_ |
+| `CreateDoubleLockPassword` | _(default)_ |
+| `DoubleLockNoAccess` | _(default)_ |
+| `CannotView` | _(default)_ |
+| `RequiresUndelete` | _(default)_ |
+| `RequiresCheckoutPendingRPC` | _(default)_ |
+| `RequiresCheckoutAndComment` | _(default)_ |
+
+

--- a/docs/types/secrets/SshLauncherSettings.md
+++ b/docs/types/secrets/SshLauncherSettings.md
@@ -1,0 +1,27 @@
+---
+title: SshLauncherSettings
+parent: Secrets
+grand_parent: Types
+---
+
+# SshLauncherSettings
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.SshLauncherSettings`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `CanConnectAsCredentials` | `bool` | read/write | — |
+| `LauncherType` | `string` | read/write | — |
+| `SecretId` | `int` | read/write | — |
+| `SecretName` | `string` | read/write | — |
+| `SshKeyExtendedTypeId` | `int` | read/write | — |
+
+

--- a/docs/types/secrets/Summary.md
+++ b/docs/types/secrets/Summary.md
@@ -1,0 +1,52 @@
+---
+title: Summary
+parent: Secrets
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.Summary`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `AutoChangeEnabled` | `bool` | read/write | — |
+| `CheckedOut` | `bool` | read/write | — |
+| `CheckOutEnabled` | `bool` | read/write | — |
+| `checkOutUserId` | `int` | read/write | — |
+| `checkOutUserName` | `string` | read/write | — |
+| `CreateDate` | `DateTime?` | read/write | — |
+| `DaysUntilExpiration` | `int` | read/write | — |
+| `DoubleLockEnabled` | `bool` | read/write | — |
+| `ExtendedFields` | `SummaryExtendedField[]` | read/write | — |
+| `FolderId` | `int` | read/write | — |
+| `folderPath` | `string` | read/write | — |
+| `HasLauncher` | `bool` | read/write | — |
+| `HidePassword` | `bool` | read/write | — |
+| `hsmKeyIdentifier` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `InheritsPermissions` | `bool` | read/write | — |
+| `IsOutOfSync` | `bool` | read/write | — |
+| `IsRestricted` | `bool` | read/write | — |
+| `LastAccessed` | `DateTime?` | read/write | — |
+| `LastHeartbeatStatus` | `SecretHeartbeatStatus` | read/write | — |
+| `LastPasswordChangeAttempt` | `DateTime?` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `OutOfSyncReason` | `string` | read/write | — |
+| `RequiresApproval` | `bool` | read/write | — |
+| `RequiresComment` | `bool` | read/write | — |
+| `ResponseCodes` | `string[]` | read/write | — |
+| `SecretTemplateId` | `int` | read/write | — |
+| `SecretTemplateName` | `string` | read/write | — |
+| `SiteId` | `int` | read/write | — |
+
+

--- a/docs/types/secrets/SummaryExtendedField.md
+++ b/docs/types/secrets/SummaryExtendedField.md
@@ -1,0 +1,24 @@
+---
+title: SummaryExtendedField
+parent: Secrets
+grand_parent: Types
+---
+
+# SummaryExtendedField
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Secrets.SummaryExtendedField`  
+**Namespace:** `Thycotic.PowerShell.Secrets`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Name` | `string` | read/write | — |
+| `Value` | `string` | read/write | — |
+
+

--- a/docs/types/secrets/readme.md
+++ b/docs/types/secrets/readme.md
@@ -1,0 +1,11 @@
+---
+title: Secrets
+parent: Types
+has_children: true
+---
+
+# Secrets
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/server-nodes/List.md
+++ b/docs/types/server-nodes/List.md
@@ -1,0 +1,39 @@
+---
+title: List
+parent: Server Nodes
+grand_parent: Types
+---
+
+# List
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.ServerNodes.List`  
+**Namespace:** `Thycotic.PowerShell.ServerNodes`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `BackgroundWorkerError` | `string` | read/write | — |
+| `BinaryVersion` | `string` | read/write | — |
+| `Database` | `string` | read/write | — |
+| `EnableBackgroundWorker` | `bool` | read/write | — |
+| `EnableEngineWorker` | `bool` | read/write | — |
+| `EnableSessionRecordingWorker` | `bool` | read/write | — |
+| `EngineWorkerError` | `string` | read/write | — |
+| `ErrorMessage` | `string` | read/write | — |
+| `InCluster` | `bool` | read/write | — |
+| `IsCurrentNode` | `bool` | read/write | — |
+| `LastConnected` | `DateTime?` | read/write | — |
+| `loglevel` | `string` | read/write | — |
+| `MachineName` | `string` | read/write | — |
+| `NodeId` | `int` | read/write | — |
+| `ReadonlyModeEnabled` | `bool` | read/write | — |
+| `ReadonlyModeStatus` | `string` | read/write | — |
+| `SessionRecordingWorkerError` | `string` | read/write | — |
+
+

--- a/docs/types/server-nodes/readme.md
+++ b/docs/types/server-nodes/readme.md
@@ -1,0 +1,11 @@
+---
+title: Server Nodes
+parent: Types
+has_children: true
+---
+
+# Server Nodes
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/users/AuditSummary.md
+++ b/docs/types/users/AuditSummary.md
@@ -1,0 +1,32 @@
+---
+title: AuditSummary
+parent: Users
+grand_parent: Types
+---
+
+# AuditSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.AuditSummary`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Action` | `string` | read/write | — |
+| `DatabaseName` | `string` | read/write | — |
+| `DateRecorded` | `DateTime?` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `DisplayNameAffected` | `string` | read/write | — |
+| `IpAddress` | `string` | read/write | — |
+| `MachineName` | `string` | read/write | — |
+| `Notes` | `string` | read/write | — |
+| `UserId` | `int` | read/write | — |
+| `UserIdAffected` | `int` | read/write | — |
+
+

--- a/docs/types/users/CurrentUser.md
+++ b/docs/types/users/CurrentUser.md
@@ -1,0 +1,33 @@
+---
+title: CurrentUser
+parent: Users
+grand_parent: Types
+---
+
+# CurrentUser
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.CurrentUser`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AdminLinks` | `MenuLink[]` | read/write | — |
+| `DateOptionId` | `int` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `EmailAddress` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Permissions` | `RolePermission[]` | read/write | — |
+| `ProfileLinks` | `MenuLink[]` | read/write | — |
+| `TimeOptionId` | `int` | read/write | — |
+| `UserLcid` | `int` | read/write | — |
+| `Username` | `string` | read/write | — |
+| `UserTheme` | `string` | read/write | — |
+
+

--- a/docs/types/users/GroupAssignedRole.md
+++ b/docs/types/users/GroupAssignedRole.md
@@ -1,0 +1,24 @@
+---
+title: GroupAssignedRole
+parent: Users
+grand_parent: Types
+---
+
+# GroupAssignedRole
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.GroupAssignedRole`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `GroupId` | `int` | read/write | — |
+| `GroupName` | `string` | read/write | — |
+
+

--- a/docs/types/users/Lookup.md
+++ b/docs/types/users/Lookup.md
@@ -1,0 +1,25 @@
+---
+title: Lookup
+parent: Users
+grand_parent: Types
+---
+
+# Lookup
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.Lookup`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Email` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `Username` | `string` | read/write | — |
+
+

--- a/docs/types/users/MenuLink.md
+++ b/docs/types/users/MenuLink.md
@@ -1,0 +1,24 @@
+---
+title: MenuLink
+parent: Users
+grand_parent: Types
+---
+
+# MenuLink
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.MenuLink`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Link` | `string` | read/write | — |
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/users/OwnerSummary.md
+++ b/docs/types/users/OwnerSummary.md
@@ -1,0 +1,28 @@
+---
+title: OwnerSummary
+parent: Users
+grand_parent: Types
+---
+
+# OwnerSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.OwnerSummary`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `DomainId` | `int` | read/write | — |
+| `GroupId` | `int` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `IsUser` | `bool` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `UserId` | `int` | read/write | — |
+
+

--- a/docs/types/users/RolePermission.md
+++ b/docs/types/users/RolePermission.md
@@ -1,0 +1,23 @@
+---
+title: RolePermission
+parent: Users
+grand_parent: Types
+---
+
+# RolePermission
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.RolePermission`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Name` | `string` | read/write | — |
+
+

--- a/docs/types/users/RoleSummary.md
+++ b/docs/types/users/RoleSummary.md
@@ -1,0 +1,24 @@
+---
+title: RoleSummary
+parent: Users
+grand_parent: Types
+---
+
+# RoleSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.RoleSummary`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Name` | `string` | read/write | — |
+| `RoleId` | `int` | read/write | — |
+
+

--- a/docs/types/users/Summary.md
+++ b/docs/types/users/Summary.md
@@ -1,0 +1,37 @@
+---
+title: Summary
+parent: Users
+grand_parent: Types
+---
+
+# Summary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.Summary`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Created` | `DateTime?` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `DomainId` | `int` | read/write | — |
+| `DomainName` | `string` | read/write | — |
+| `EmailAddress` | `string` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `ExternalUserSource` | `string` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `IsApplicationAccount` | `bool` | read/write | — |
+| `IsLockedOut` | `bool` | read/write | — |
+| `LastLogin` | `DateTime?` | read/write | — |
+| `LoginFailures` | `int` | read/write | — |
+| `platformIntegrationType` | `string` | read/write | — |
+| `TwoFactorMethod` | `string` | read/write | — |
+| `Username` | `string` | read/write | — |
+
+

--- a/docs/types/users/TwoFactorTypes.md
+++ b/docs/types/users/TwoFactorTypes.md
@@ -1,0 +1,22 @@
+---
+title: TwoFactorTypes
+parent: Users
+grand_parent: Types
+---
+
+# TwoFactorTypes
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.TwoFactorTypes`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `DUO` | _(default)_ |
+| `FIDO` | _(default)_ |
+| `RADIUS` | _(default)_ |
+| `OATH` | _(default)_ |
+
+

--- a/docs/types/users/UnixAuthenticationType.md
+++ b/docs/types/users/UnixAuthenticationType.md
@@ -1,0 +1,22 @@
+---
+title: UnixAuthenticationType
+parent: Users
+grand_parent: Types
+---
+
+# UnixAuthenticationType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.UnixAuthenticationType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `Password` | _(default)_ |
+| `PublicKey` | _(default)_ |
+| `PasswordOrPublicKey` | _(default)_ |
+| `PasswordAndPublicKey` | _(default)_ |
+
+

--- a/docs/types/users/User.md
+++ b/docs/types/users/User.md
@@ -1,0 +1,61 @@
+---
+title: User
+parent: Users
+grand_parent: Types
+---
+
+# User
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.User`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `AdAccountExpires` | `DateTime?` | read/write | — |
+| `AdGuid` | `string` | read/write | — |
+| `Created` | `DateTime?` | read/write | — |
+| `DateOptionId` | `int` | read/write | — |
+| `DisplayName` | `string` | read/write | — |
+| `DomainId` | `int` | read/write | — |
+| `DuoTwoFactor` | `bool` | read/write | — |
+| `EmailAddress` | `string` | read/write | — |
+| `Enabled` | `bool` | read/write | — |
+| `ExternalUserSource` | `UserSourceType` | read/write | — |
+| `Fido2TwoFactor` | `bool` | read/write | — |
+| `Id` | `int` | read/write | — |
+| `ipAddressRestrictions` | `string` | read/write | — |
+| `IsApplicationAccount` | `bool` | read/write | — |
+| `IsEmailCopiedFromAD` | `bool` | read/write | — |
+| `IsEmailVerified` | `bool` | read/write | — |
+| `IsLockedOut` | `bool` | read/write | — |
+| `LastLogin` | `DateTime?` | read/write | — |
+| `LastSessionActivity` | `DateTime?` | read/write | — |
+| `LockOutReason` | `string` | read/write | — |
+| `LockOutReasonDescription` | `string` | read/write | — |
+| `LoginFailures` | `int` | read/write | — |
+| `MustVerifyEmail` | `bool` | read/write | — |
+| `OathTwoFactor` | `bool` | read/write | — |
+| `OathVerified` | `bool` | read/write | — |
+| `PasswordLastChanged` | `DateTime?` | read/write | — |
+| `personalGroupId` | `int` | read/write | — |
+| `platformIntegrationType` | `string` | read/write | — |
+| `platformServiceUser` | `bool` | read/write | — |
+| `RadiusTwoFactor` | `bool` | read/write | — |
+| `RadiusUserName` | `string` | read/write | — |
+| `ResetSessionStarted` | `DateTime?` | read/write | — |
+| `SlackId` | `int` | read/write | — |
+| `TimeOptionId` | `int` | read/write | — |
+| `TwoFactor` | `bool` | read/write | — |
+| `UnixAuthenticationMethod` | `UnixAuthenticationType` | read/write | — |
+| `UserLcid` | `int` | read/write | — |
+| `Username` | `string` | read/write | — |
+| `verifyEmailSentDate` | `DateTime?` | read/write | — |
+
+

--- a/docs/types/users/UserRoleSummary.md
+++ b/docs/types/users/UserRoleSummary.md
@@ -1,0 +1,26 @@
+---
+title: UserRoleSummary
+parent: Users
+grand_parent: Types
+---
+
+# UserRoleSummary
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.Users.UserRoleSummary`  
+**Namespace:** `Thycotic.PowerShell.Users`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Groups` | `GroupAssignedRole[]` | read/write | — |
+| `IsDirectAssignment` | `bool` | read/write | — |
+| `RoleId` | `int` | read/write | — |
+| `RoleName` | `string` | read/write | — |
+
+

--- a/docs/types/users/UserSourceType.md
+++ b/docs/types/users/UserSourceType.md
@@ -1,0 +1,21 @@
+---
+title: UserSourceType
+parent: Users
+grand_parent: Types
+---
+
+# UserSourceType
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.UserSourceType`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `None` | _(default)_ |
+| `ThycoticOne` | _(default)_ |
+| `Azure` | _(default)_ |
+
+

--- a/docs/types/users/readme.md
+++ b/docs/types/users/readme.md
@@ -1,0 +1,11 @@
+---
+title: Users
+parent: Types
+has_children: true
+---
+
+# Users
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/workflow-templates/Detail.md
+++ b/docs/types/workflow-templates/Detail.md
@@ -1,0 +1,31 @@
+---
+title: Detail
+parent: Workflow Templates
+grand_parent: Types
+---
+
+# Detail
+
+**Kind:** class  
+**Full name:** `Thycotic.PowerShell.WorkflowTemplates.Detail`  
+**Namespace:** `Thycotic.PowerShell.WorkflowTemplates`  
+
+## Constructors
+
+- `new()` _(default)_
+
+## Properties
+
+| Name | Type | Access | Default |
+|---|---|---|---|
+| `Active` | `bool` | read/write | — |
+| `ConfigurationJson` | `string` | read/write | — |
+| `Description` | `string` | read/write | — |
+| `ExpirationMinutes` | `int` | read/write | — |
+| `Name` | `string` | read/write | — |
+| `Reusable` | `bool` | read/write | — |
+| `TypeName` | `string` | read/write | — |
+| `WorkflowTemplateId` | `int` | read/write | — |
+| `WorkflowType` | `string` | read/write | — |
+
+

--- a/docs/types/workflow-templates/readme.md
+++ b/docs/types/workflow-templates/readme.md
@@ -1,0 +1,11 @@
+---
+title: Workflow Templates
+parent: Types
+has_children: true
+---
+
+# Workflow Templates
+
+{% include list.liquid all=true %}
+
+

--- a/docs/types/workflows/WorkflowTypes.md
+++ b/docs/types/workflows/WorkflowTypes.md
@@ -1,0 +1,20 @@
+---
+title: WorkflowTypes
+parent: Workflows
+grand_parent: Types
+---
+
+# WorkflowTypes
+
+**Kind:** enum  
+**Full name:** `Thycotic.PowerShell.Enums.WorkflowTypes`  
+**Namespace:** `Thycotic.PowerShell.Enums`  
+
+## Values
+
+| Name | Value |
+|---|---|
+| `AccessRequest` | _(default)_ |
+| `SecretEraseRequest` | _(default)_ |
+
+

--- a/docs/types/workflows/readme.md
+++ b/docs/types/workflows/readme.md
@@ -1,0 +1,11 @@
+---
+title: Workflows
+parent: Types
+has_children: true
+---
+
+# Workflows
+
+{% include list.liquid all=true %}
+
+

--- a/scripts/docs/Generate-TypeDocs.ps1
+++ b/scripts/docs/Generate-TypeDocs.ps1
@@ -1,0 +1,266 @@
+<#
+.SYNOPSIS
+    Generate per-type reference markdown for docs/types/ from C# source.
+
+.DESCRIPTION
+    Walks src/Thycotic.SecretServer/classes/ and src/Thycotic.SecretServer/enums/,
+    parses each .cs file with simple regex (the files are POCOs/enums, no fancy
+    C# features), and emits one Jekyll/just-the-docs page per type under
+    docs/types/<category>/<TypeName>.md plus a readme.md index per category and
+    a top-level docs/types/readme.md.
+
+    Re-run to regenerate after C# changes.
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path,
+    [int]$NavOrder = 4
+)
+
+$ErrorActionPreference = 'Stop'
+$classesRoot = Join-Path $RepoRoot 'src/Thycotic.SecretServer/classes'
+$enumsRoot   = Join-Path $RepoRoot 'src/Thycotic.SecretServer/enums'
+$docsRoot    = Join-Path $RepoRoot 'docs/types'
+
+function ConvertTo-Title {
+    param([string]$Kebab)
+    ($Kebab -split '-' | ForEach-Object {
+        if ($_.Length -eq 0) { return $_ }
+        $_.Substring(0, 1).ToUpper() + $_.Substring(1)
+    }) -join ' '
+}
+
+function Parse-ClassFile {
+    param([string]$Path)
+
+    $src = Get-Content -Raw -Path $Path
+    $ns  = if ($src -match 'namespace\s+([\w\.]+)') { $Matches[1] } else { $null }
+
+    $type = $null
+    if ($src -match 'public\s+(class|enum)\s+(\w+)(?:\s*:\s*([\w\.,\s<>?]+?))?\s*\{') {
+        $type = [pscustomobject]@{
+            Kind      = $Matches[1]
+            Name      = $Matches[2]
+            BaseList  = if ($Matches[3]) { ($Matches[3].Trim() -split '\s*,\s*') } else { @() }
+            FullName  = "$ns.$($Matches[2])"
+            Namespace = $ns
+        }
+    }
+    if (-not $type) { return $null }
+
+    if ($type.Kind -eq 'enum') {
+        $values = @()
+        $body = if ($src -match '(?ms)enum\s+\w+[^{]*\{([^}]*)\}') { $Matches[1] } else { '' }
+        foreach ($line in ($body -split '\r?\n')) {
+            $stripped = $line -replace '//.*$', '' -replace '/\*.*?\*/', ''
+            $stripped = $stripped.Trim().TrimEnd(',')
+            if (-not $stripped) { continue }
+            if ($stripped -match '^(\w+)\s*=\s*(.+)$') {
+                $values += [pscustomobject]@{ Name = $Matches[1]; Value = $Matches[2].Trim() }
+            } elseif ($stripped -match '^(\w+)$') {
+                $values += [pscustomobject]@{ Name = $Matches[1]; Value = $null }
+            }
+        }
+        return [pscustomobject]@{
+            Kind = 'enum'; Type = $type; Values = $values
+        }
+    }
+
+    # class — extract properties and methods
+    $properties = @()
+    foreach ($m in [regex]::Matches($src, 'public\s+(?<type>[\w\.\<\>\[\]\?\,\s]+?)\s+(?<name>\w+)\s*\{\s*(?<accessors>get;(?:\s*set;)?)\s*\}(?:\s*=\s*(?<default>[^;]+);)?')) {
+        $accessors = $m.Groups['accessors'].Value -replace '\s+', ''
+        $isReadonly = ($accessors -eq 'get;')
+        $properties += [pscustomobject]@{
+            Type     = ($m.Groups['type'].Value -replace '\s+', ' ').Trim()
+            Name     = $m.Groups['name'].Value
+            Readonly = $isReadonly
+            Default  = if ($m.Groups['default'].Success) { $m.Groups['default'].Value.Trim() } else { $null }
+        }
+    }
+
+    $methods = @()
+    # signature only — body discarded
+    foreach ($m in [regex]::Matches($src, '(?ms)public\s+(?!class\b|enum\b)(?<ret>[\w\.\<\>\[\]\?\,\s]+?)\s+(?<name>\w+)\s*\((?<args>[^\)]*)\)\s*\{')) {
+        $ret = ($m.Groups['ret'].Value -replace '\s+', ' ').Trim()
+        # exclude property accessors that the property regex didn't catch
+        if ($ret -eq 'string' -or $ret -eq 'int' -or $ret -eq 'bool' -or $ret -eq 'void' -or $ret -match '^[A-Z]') {
+            $methods += [pscustomobject]@{
+                ReturnType = $ret
+                Name       = $m.Groups['name'].Value
+                Args       = $m.Groups['args'].Value.Trim()
+            }
+        }
+    }
+    # filter out the type's own constructor (same name as the type)
+    $ctors  = $methods | Where-Object { $_.Name -eq $type.Name }
+    $methods = $methods | Where-Object { $_.Name -ne $type.Name }
+
+    return [pscustomobject]@{
+        Kind = 'class'; Type = $type; Properties = $properties; Methods = $methods; Constructors = $ctors
+    }
+}
+
+function Format-TypeMarkdown {
+    param($Parsed, [string]$Category)
+
+    $t = $Parsed.Type
+    $title = $t.Name
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine('---')
+    [void]$sb.AppendLine("title: $title")
+    [void]$sb.AppendLine("parent: $(ConvertTo-Title $Category)")
+    [void]$sb.AppendLine("grand_parent: Types")
+    [void]$sb.AppendLine('---')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("# $title")
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("**Kind:** $($Parsed.Kind)  ")
+    [void]$sb.AppendLine("**Full name:** ``$($t.FullName)``  ")
+    [void]$sb.AppendLine("**Namespace:** ``$($t.Namespace)``  ")
+    if ($t.BaseList.Count -gt 0) {
+        [void]$sb.AppendLine("**Inherits / implements:** $($t.BaseList -join ', ')  ")
+    }
+    [void]$sb.AppendLine()
+
+    if ($Parsed.Kind -eq 'enum') {
+        [void]$sb.AppendLine("## Values")
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('| Name | Value |')
+        [void]$sb.AppendLine('|---|---|')
+        foreach ($v in $Parsed.Values) {
+            $val = if ($null -ne $v.Value) { "``$($v.Value)``" } else { '_(default)_' }
+            [void]$sb.AppendLine("| ``$($v.Name)`` | $val |")
+        }
+        [void]$sb.AppendLine()
+        return $sb.ToString()
+    }
+
+    if ($Parsed.Constructors.Count -gt 0) {
+        [void]$sb.AppendLine("## Constructors")
+        [void]$sb.AppendLine()
+        foreach ($c in $Parsed.Constructors) {
+            $argText = if ($c.Args) { $c.Args } else { '' }
+            [void]$sb.AppendLine("- ``$($c.Name)($argText)``")
+        }
+        [void]$sb.AppendLine()
+    } else {
+        [void]$sb.AppendLine("## Constructors")
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine("- ``new()`` _(default)_")
+        [void]$sb.AppendLine()
+    }
+
+    if ($Parsed.Properties.Count -gt 0) {
+        [void]$sb.AppendLine("## Properties")
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('| Name | Type | Access | Default |')
+        [void]$sb.AppendLine('|---|---|---|---|')
+        foreach ($p in ($Parsed.Properties | Sort-Object Name)) {
+            $access = if ($p.Readonly) { 'readonly' } else { 'read/write' }
+            $default = if ($p.Default) { "``$($p.Default)``" } else { '—' }
+            [void]$sb.AppendLine("| ``$($p.Name)`` | ``$($p.Type)`` | $access | $default |")
+        }
+        [void]$sb.AppendLine()
+    }
+
+    if ($Parsed.Methods.Count -gt 0) {
+        [void]$sb.AppendLine("## Methods")
+        [void]$sb.AppendLine()
+        foreach ($mm in ($Parsed.Methods | Sort-Object Name)) {
+            $argText = if ($mm.Args) { $mm.Args } else { '' }
+            [void]$sb.AppendLine("- ``[$($mm.ReturnType)] $($mm.Name)($argText)``")
+        }
+        [void]$sb.AppendLine()
+    }
+
+    return $sb.ToString()
+}
+
+function Write-CategoryIndex {
+    param([string]$Path, [string]$Title, [string]$Parent, [int]$NavOrder = $null)
+
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine('---')
+    [void]$sb.AppendLine("title: $Title")
+    if ($Parent) { [void]$sb.AppendLine("parent: $Parent") }
+    if ($NavOrder) { [void]$sb.AppendLine("nav_order: $NavOrder") }
+    [void]$sb.AppendLine("has_children: true")
+    [void]$sb.AppendLine('---')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("# $Title")
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("{% include list.liquid all=true %}")
+    [void]$sb.AppendLine()
+    Set-Content -Path $Path -Value $sb.ToString() -Encoding UTF8
+}
+
+# --- main ---
+
+# Reset docs/types
+if (Test-Path $docsRoot) {
+    Remove-Item -Recurse -Force $docsRoot
+}
+New-Item -ItemType Directory -Force -Path $docsRoot | Out-Null
+
+# Top-level index
+$topIndex = Join-Path $docsRoot 'readme.md'
+$sb = [System.Text.StringBuilder]::new()
+[void]$sb.AppendLine('---')
+[void]$sb.AppendLine('title: Types')
+[void]$sb.AppendLine("nav_order: $NavOrder")
+[void]$sb.AppendLine('has_children: true')
+[void]$sb.AppendLine('---')
+[void]$sb.AppendLine()
+[void]$sb.AppendLine('# Types')
+[void]$sb.AppendLine()
+[void]$sb.AppendLine('Reference for the C# classes and enums exposed by the Thycotic.SecretServer module.')
+[void]$sb.AppendLine('Each page lists the full type name, namespace, properties, methods, and (for enums) numeric values.')
+[void]$sb.AppendLine('These pages are auto-generated from the C# source under `src/Thycotic.SecretServer/`.')
+[void]$sb.AppendLine()
+[void]$sb.AppendLine('{% include list.liquid all=true %}')
+[void]$sb.AppendLine()
+Set-Content -Path $topIndex -Value $sb.ToString() -Encoding UTF8
+
+# Walk both classes/ and enums/ — combine into same per-category folder
+$sourceRoots = @($classesRoot, $enumsRoot)
+$parsedByCategory = @{}
+$counts = @{ class = 0; enum = 0; skipped = 0 }
+
+foreach ($root in $sourceRoots) {
+    if (-not (Test-Path $root)) { continue }
+    foreach ($file in Get-ChildItem -Path $root -Recurse -Filter *.cs) {
+        $rel = $file.FullName.Substring($root.Length).TrimStart([char]'\', [char]'/')
+        $parts = $rel -split '[\\/]'
+        $category = if ($parts.Length -ge 2) { $parts[0] } else { 'common' }
+        $parsed = Parse-ClassFile -Path $file.FullName
+        if (-not $parsed) {
+            Write-Warning "Could not parse $($file.FullName)"
+            $counts.skipped++
+            continue
+        }
+        if (-not $parsedByCategory.ContainsKey($category)) { $parsedByCategory[$category] = @() }
+        $parsedByCategory[$category] += $parsed
+        $counts[$parsed.Kind]++
+    }
+}
+
+# Emit per-type pages + per-category index
+$categories = $parsedByCategory.Keys | Sort-Object
+foreach ($cat in $categories) {
+    $catDir = Join-Path $docsRoot $cat
+    New-Item -ItemType Directory -Force -Path $catDir | Out-Null
+
+    $catTitle = ConvertTo-Title $cat
+    Write-CategoryIndex -Path (Join-Path $catDir 'readme.md') -Title $catTitle -Parent 'Types'
+
+    foreach ($parsed in ($parsedByCategory[$cat] | Sort-Object { $_.Type.Name })) {
+        $md = Format-TypeMarkdown -Parsed $parsed -Category $cat
+        $out = Join-Path $catDir "$($parsed.Type.Name).md"
+        Set-Content -Path $out -Value $md -Encoding UTF8
+    }
+}
+
+Write-Host ""
+Write-Host "Generated $($counts.class) classes, $($counts.enum) enums, skipped $($counts.skipped) (categories: $($categories.Count))"
+Write-Host "Output: $docsRoot"


### PR DESCRIPTION
## Summary
The original per-class help under `docs/about_topics/` was removed in commit 808eb3eec5 (2021-08-29, "doc updates"). The README's link to that path has been a dead 404 for ~4 years, and the live site has had no published reference for the module's 174 classes / 45 enums.

This PR restores a per-type reference under a new path — `docs/types/` — that mirrors the `docs/commands/` layout (one folder per category, one page per type, just-the-docs nav frontmatter).

## What's in the PR
- **`scripts/docs/Generate-TypeDocs.ps1`** — new generator. Walks `src/Thycotic.SecretServer/classes/` and `src/Thycotic.SecretServer/enums/`, parses each `.cs` (simple POCOs, no AST tool needed), and emits one Jekyll markdown page per type with frontmatter that plugs into the existing just-the-docs nav (`parent` / `grand_parent`). Re-run after any class or enum change.
- **`docs/types/`** — 219 type pages across 33 categories (configurations, secrets, users, distributed-engines, …), plus 33 per-category `readme.md` index pages and 1 top-level `docs/types/readme.md` (nav_order 4).
  - Each class page lists full name, namespace, base/interfaces, constructors, a properties table (name / type / access / default), and methods (signature).
  - Each enum page lists full name and a values table (name / numeric).
- **`README.md`** — point the "Classes" section at the new `https://thycotic-ps.github.io/thycotic.secretserver/types/` URL and document how to regenerate.

## Differences from the old `about_topics/`
- The old pages had hand-curated per-property descriptions ("All emails will be sent from this address"); the C# source has no XML doc-comments to reuse, so the regenerated pages list type and access only. If short descriptions are wanted, the path forward is `<summary>` comments in the C# source — the generator already picks them up if/when added (drop-in regex hook).
- Categories combine classes and enums under one per-category folder (e.g. `docs/types/secrets/Lookup.md` next to `docs/types/secrets/SecretHeartbeatStatus.md`) rather than split across `about_topics/{authentication,configurations,…}` only.

## Test plan
- [x] Generator runs clean: 174 classes + 45 enums, 0 parse skips
- [x] Nav frontmatter matches `docs/commands/` pattern (verified against `docs/commands/secrets/Get-TssSecret.md` and `docs/commands/secrets/readme.md`)
- [x] Spot-checked: `Session` (complex w/ methods + defaults), `PasswordType` (array of nested type), `General` (nested class properties), `SecretHeartbeatStatus` (enum with numeric values)
- [ ] Jekyll site builds without 404 in nav after merge (gh-pages action will confirm)

Closes nothing on its own — restores reference content that's been missing since v0.61.x.