### PR TITLE
docs: sync install.md release links with README (v0.62.0)

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -18,9 +18,10 @@ nav_order: 1
 
 `Thycotic.SecretServer` is available to download from the following locations:
 
-- [GitHub Releases](https://github.com/thycotic-ps/thycotic.secretserver/releases/latest)
-- **[Direct download](https://downloads.marketplace.delinea.com/integrations/Downloads/PowershellModule/0.61.3/Thycotic.SecretServer.zip) Current Release**
-- *[PowerShell Gallery](https://www.powershellgallery.com/packages/Thycotic.SecretServer/) Release 61.3*
+- ~~[PowerShell Gallery](https://www.powershellgallery.com/packages/Thycotic.SecretServer/) (recommended)~~ Temporarily unavailable
+- [GitHub Release](https://github.com/thycotic-ps/thycotic.secretserver/releases/)
+- [CDN Download](https://downloads.marketplace.delinea.com/integrations/Downloads/PowershellModule/0.62.0/Thycotic.SecretServer.zip)
+- [Direct Download](https://delineamarketplace01qa.blob.core.windows.net/integrations/Downloads/PowershellModule/0.62.0/Thycotic.SecretServer.zip)
 
 Choose one of the following methods to obtain & install the module:
 
@@ -47,9 +48,15 @@ There are multiple options for downloading the module files:
 2. Unblock & Extract the `Thycotic.SecretServer.zip`
 3. Copy the `Thycotic.SecretServer` folder to your "Powershell Modules" directory of choice.
 
-### Direct File Download
+### CDN Download
 
-1. [Download the latest release file](https://downloads.marketplace.delinea.com/integrations/Downloads/PowershellModule/0.61.3/Thycotic.SecretServer.zip)
+1. [Download the latest release file](https://downloads.marketplace.delinea.com/integrations/Downloads/PowershellModule/0.62.0/Thycotic.SecretServer.zip)
+2. Unblock & Extract the archive
+3. Copy the `Thycotic.SecretServer` folder to your "Powershell Modules" directory of choice.
+
+### Direct Download
+
+1. [Download the latest release file](https://delineamarketplace01qa.blob.core.windows.net/integrations/Downloads/PowershellModule/0.62.0/Thycotic.SecretServer.zip)
 2. Unblock & Extract the archive
 3. Copy the `Thycotic.SecretServer` folder to your "Powershell Modules" directory of choice.
 


### PR DESCRIPTION
## Summary

- Align the Installation docs page with the README's release source list
- All download links now point at v0.62.0 (was v0.61.3)
- Split the old "Direct File Download" section into separate CDN Download and Direct Download sections to match the README structure
- PSGallery shown as struck-through with a "temporarily unavailable" note, matching README treatment

## Test plan

- [ ] Visual diff in rendered Jekyll output (or the GitHub markdown preview) shows the four bullets matching README
- [ ] All four download links resolve (GitHub Releases, CDN, Direct, PSGallery package page)
- [ ] No other docs pages broke (no internal links pointed at the removed "Direct File Download" anchor)

Generated with [Claude Code](https://claude.com/claude-code)