### PR TITLE
docs: refresh install, auth, troubleshooting for v0.62.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ See the Disclaimer at the bottom of this page for other legal jargon. This modul
 
 This project strives to cover all types of environments. We understand that some do not allow pulling PowerShell modules from every resource. The following sources are available for downloading each release of the module:
 
-- ~~PowerShell Gallery <!-- (https://www.powershellgallery.com/packages/Thycotic.SecretServer/) --> (recommended)~~ Temporarily unavailable
-- [GitHub Release](https://github.com/thycotic-ps/thycotic.secretserver/releases/)
+- [GitHub Release](https://github.com/thycotic-ps/thycotic.secretserver/releases/) (current: v0.62.0)
 - [CDN Download](https://downloads.marketplace.delinea.com/integrations/Downloads/PowershellModule/0.62.0/Thycotic.SecretServer.zip)
 - [Direct Download](https://delineamarketplace01qa.blob.core.windows.net/integrations/Downloads/PowershellModule/0.62.0/Thycotic.SecretServer.zip)
+- [PowerShell Gallery](https://www.powershellgallery.com/packages/Thycotic.SecretServer/) — **not updated past 0.60.4** (tracking: [#450](https://github.com/thycotic-ps/thycotic.secretserver/issues/450))
 
 Documentation on installing the module can be found on the documentation site [here](https://thycotic-ps.github.io/thycotic.secretserver/getting_started/install.html)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,11 +5,13 @@ nav_order: 1
 
 # Secret Server PowerShell Module
 
-Welcome to the documentation site for the `Thycotic.SecretServer` module. You can use this module for automating your workflows in your environment to retrieve needed credentials securely. The module supports cross-platform use and can be used on Windows PowerShell and version PowerShell 7 or higher.
+Welcome to the documentation site for the `Thycotic.SecretServer` module. You can use this module for automating your workflows in your environment to retrieve needed credentials securely. The module supports cross-platform use and runs on PowerShell 7+; Windows PowerShell 5.1 is supported for older module releases.
 
 You can browse the [Getting Started](https://thycotic-ps.github.io/thycotic.secretserver/getting_started/) section to find details on installation, how to authenticate and working examples using the module.
 
 The [Commands](https://thycotic-ps.github.io/thycotic.secretserver/commands/) section contains the help content on each function that can also be accessed using `Get-Help` in your PowerShell session.
+
+See the [release notes](https://github.com/thycotic-ps/thycotic.secretserver/blob/dev/CHANGELOG.md) for the latest changes, including breaking changes and new features per release.
 
 # Support & Disclaimer
 

--- a/docs/commands/authentication/New-TssSession.md
+++ b/docs/commands/authentication/New-TssSession.md
@@ -12,24 +12,26 @@ Create new session
 
 ### clientSdk
 ```
-New-TssSession -SecretServer <Uri> [-UseSdkClient] -ConfigPath <String> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+New-TssSession -SecretServer <Uri> [-UseSdkClient] -ConfigPath <String> [-SkipCertificateCheck] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### winauth
 ```
-New-TssSession -SecretServer <Uri> [-UseWindowsAuth] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-TssSession -SecretServer <Uri> [-UseWindowsAuth] [-SkipCertificateCheck] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### sdk
 ```
-New-TssSession -SecretServer <Uri> -AccessToken <Object> [-WhatIf] [-Confirm] [<CommonParameters>]
+New-TssSession -SecretServer <Uri> -AccessToken <Object> [-SkipCertificateCheck] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### new
 ```
-New-TssSession -SecretServer <Uri> [-Credential] <PSCredential> [[-OtpCode] <Int32>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+New-TssSession -SecretServer <Uri> [-Credential] <PSCredential> [[-OtpCode] <String>] [-SkipCertificateCheck]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -134,16 +136,17 @@ Accept wildcard characters: False
 ```
 
 ### -OtpCode
-Provide 2FA code
+Provide 2FA code.
+Quote the value to preserve any leading zeros (e.g. `'012345'`).
 
 ```yaml
-Type: Int32
+Type: String
 Parameter Sets: new
 Aliases:
 
 Required: False
 Position: 3
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -204,6 +207,24 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Skip TLS certificate validation for the session.
+Use only against lab/test Secret Server instances with self-signed certificates; this disables a key TLS protection and should not be used in production.
+
+Available in all parameter sets as of v0.62.0 (RestSharp 112 no longer trusts self-signed certificates by default).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/getting_started/authentication.md
+++ b/docs/getting_started/authentication.md
@@ -15,9 +15,24 @@ To utilize Windows Authentication with Secret Server, your administrator will ne
 
 As of **version `0.30.0`**, Windows Authentication is supported with the module. `New-TssSession` now has the parameter `-UseWindowsAuth` for this purpose. See examples of this use via the command help
 
+## Self-signed certificates / TLS
+
+As of **version `0.62.0`**, the module's underlying HTTP client (RestSharp 112) no longer trusts self-signed certificates by default. If your Secret Server instance uses a self-signed or otherwise untrusted certificate, you will see a `TaskCanceledException` or an empty error response when calling `New-TssSession`.
+
+Use the `-SkipCertificateCheck` switch to bypass certificate validation for that session:
+
+```powershell
+$cred = Get-Credential
+$session = New-TssSession -SecretServer https://vault.lab.local -Credential $cred -SkipCertificateCheck
+```
+
+> **Warning** `-SkipCertificateCheck` disables TLS certificate validation for the session and exposes you to man-in-the-middle attacks. Only use it against lab/test instances or where you have other means of verifying the endpoint. For production, install a trusted certificate on your Secret Server host.
+
+See the [Troubleshooting](troubleshooting.md) page for related TLS errors.
+
 ## OAuth2 Authentication
 
-Authenticating with a username and password creates creating that as a `PSCredential` object and then providing that to the `-Credential` parameter of `New-TssSession`.
+Authenticating with a username and password is done by creating a `PSCredential` object and providing it to the `-Credential` parameter of `New-TssSession`.
 
 ### Interactive Login
 
@@ -127,13 +142,14 @@ code-insiders $PROFILE
 Below script can be added to your profile script, adjust as you need for your environment:
 
 ```powershell
-function Login-SS {
+function Connect-SS {
+   param([switch]$IgnoreDefault)
    $ssUrl = 'https://vault.company.com/SecretServer'
    Import-Module Thycotic.SecretServer -Force
    $cred = Get-Secret secretserverCred
    $s = New-TssSession -SecretServer $ssUrl -Credential $cred
    New-Variable -Name session -Value $s -Scope Global -Force
-   if (-not $ignoreDefault) {
+   if (-not $IgnoreDefault) {
       $PSDefaultParameterValues.Remove("*:TssSession")
       $PSDefaultParameterValues.Remove("*:PersonalAccessToken")
       $PSDefaultParameterValues.Add("*:TssSession",$session)
@@ -142,10 +158,12 @@ function Login-SS {
 }
 ```
 
+`Connect-SS` uses the approved PowerShell verb `Connect`. The `-IgnoreDefault` switch lets you skip the `$PSDefaultParameterValues` population — useful when running ad-hoc commands that need a session but should not change the global defaults.
+
 The use of `$PSDefaultParameterValues` allows you to set the default values for those parameters and applies to all commands in the module. You can see in the below example that `-TssSession` is not directly provided.
 
 ```powershell
-Login-SS
+Connect-SS
 $ad = Get-TssSecretStub -SecretTemplateId 6001 -FolderId 37
 $ad.Name = 'Test Secret with Incognito Policy 1'
 $ad.SetFieldValue('Domain','somedomain');$ad.SetFieldValue('Username','someuser');$ad.SetFieldValue('Password','somepassword');

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -6,7 +6,7 @@ nav_order: 1
 # Installation
 
 {% capture notice-text %}
-- Windows Powershell PowerShell 7+
+- PowerShell 7+ (required for new installs). Windows PowerShell 5.1 is still supported for users running older module releases — see the [Troubleshooting](troubleshooting.md) page for the TLS 1.2 setup required on 5.1.
 - Thycotic Secret Server Web Service enabled
 - A user to authenticate with appropriate permissions to access desired objects.
 {% endcapture %}
@@ -18,10 +18,10 @@ nav_order: 1
 
 `Thycotic.SecretServer` is available to download from the following locations:
 
-- ~~[PowerShell Gallery](https://www.powershellgallery.com/packages/Thycotic.SecretServer/) (recommended)~~ Temporarily unavailable
-- [GitHub Release](https://github.com/thycotic-ps/thycotic.secretserver/releases/)
+- [GitHub Release](https://github.com/thycotic-ps/thycotic.secretserver/releases/) (current: v0.62.0)
 - [CDN Download](https://downloads.marketplace.delinea.com/integrations/Downloads/PowershellModule/0.62.0/Thycotic.SecretServer.zip)
 - [Direct Download](https://delineamarketplace01qa.blob.core.windows.net/integrations/Downloads/PowershellModule/0.62.0/Thycotic.SecretServer.zip)
+- [PowerShell Gallery](https://www.powershellgallery.com/packages/Thycotic.SecretServer/) — **not updated past 0.60.4** (tracking: [#450](https://github.com/thycotic-ps/thycotic.secretserver/issues/450))
 
 Choose one of the following methods to obtain & install the module:
 
@@ -60,7 +60,15 @@ There are multiple options for downloading the module files:
 2. Unblock & Extract the archive
 3. Copy the `Thycotic.SecretServer` folder to your "Powershell Modules" directory of choice.
 
-> **Warning** **Thycotic.SecretServer.zip SHA256:** [thycotic.secretserver_hash.txt](https://thyproservices.z20.web.core.windows.net/Thycotic.SecretServer_hash.txt)
+### Integrity verification
+
+The published SHA256 hash for each release is at [thycotic.secretserver_hash.txt](https://thyproservices.z20.web.core.windows.net/Thycotic.SecretServer_hash.txt). Verify the downloaded zip before extracting:
+
+```powershell
+Get-FileHash -Algorithm SHA256 .\Thycotic.SecretServer.zip
+```
+
+Compare the output to the hash file above.
 
 ## Verification
 
@@ -72,6 +80,12 @@ Get-Module -ListAvailable Thycotic.SecretServer
 # or
 
 Get-InstalledModule Thycotic.SecretServer
+```
+
+Confirm the installed version matches the release you downloaded:
+
+```powershell
+(Get-Module -ListAvailable Thycotic.SecretServer).Version
 ```
 
 Import the module:
@@ -93,7 +107,7 @@ Get-Help Get-TssSecret -Full
 ```
 ## Option 2: Install from PowerShell Gallery
 
-*PowerShell Gallery does not contain releases after v60.4*
+> **Warning** **PowerShell Gallery is not updated past 0.60.4.** Installing from PSGallery will give you an outdated module missing the fixes and features in 0.61.x and 0.62.0. Use Option 1 (Manual Install) to get the current release. Tracking: [#450](https://github.com/thycotic-ps/thycotic.secretserver/issues/450).
 
 1. Open a PowerShell prompt
 
@@ -103,6 +117,6 @@ Get-Help Get-TssSecret -Full
 Install-Module -Name Thycotic.SecretServer -Scope CurrentUser
 ```
 
-> **Warning** **Windows PowerShell PowerShell 7+** must be used to download the module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/Thycotic.SecretServer/).
+> **Warning** **PowerShell 7+** must be used to download the module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/Thycotic.SecretServer/).
 
-> **Warning** **Windows PowerShell 5.1** TLS error: PowerShell Gallery only supports TLS 1.2 and above, errors noted [here](https://devblogs.microsoft.com/powershell/powershell-gallery-tls-support/#errors-i-might-see) may be observed. You will need to start a new PowerShell session and set TLS to 1.2: `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12`
+> **Warning** **Windows PowerShell 5.1** TLS error: PowerShell Gallery only supports TLS 1.2 and above, errors noted [here](https://devblogs.microsoft.com/powershell/powershell-gallery-tls-support/#errors-i-might-see) may be observed. You will need to start a new PowerShell session and set TLS to 1.2: `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12`. PowerShell 7 negotiates TLS automatically and does not need this step. See [Troubleshooting](troubleshooting.md) for more.

--- a/docs/getting_started/troubleshooting.md
+++ b/docs/getting_started/troubleshooting.md
@@ -1,0 +1,71 @@
+---
+parent: Getting Started
+nav_order: 6
+---
+
+# Troubleshooting
+
+Common errors and their fixes when using `Thycotic.SecretServer`.
+
+## TLS 1.2 on Windows PowerShell 5.1
+
+PowerShell Gallery and many modern web endpoints require TLS 1.2 or higher. Windows PowerShell 5.1 does not enable TLS 1.2 by default, which can produce errors like:
+
+```text
+WARNING: Unable to resolve package source 'https://www.powershellgallery.com/api/v2'.
+PackageManagement\Install-Package : No match was found for the specified search criteria...
+```
+
+Set the security protocol for the current session before calling `Install-Module` or `New-TssSession`:
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+```
+
+PowerShell 7 negotiates the highest available TLS version automatically and does not need this step.
+
+Reference: [PowerShell Gallery TLS support notes](https://devblogs.microsoft.com/powershell/powershell-gallery-tls-support/#errors-i-might-see).
+
+## `TaskCanceledException` or empty error from `New-TssSession`
+
+As of v0.62.0 the module's HTTP client (RestSharp 112) no longer trusts self-signed certificates by default. Calls against a Secret Server instance with an untrusted certificate fail silently or surface as a `TaskCanceledException`.
+
+Use `-SkipCertificateCheck` on `New-TssSession`:
+
+```powershell
+$session = New-TssSession -SecretServer https://vault.lab.local -Credential $cred -SkipCertificateCheck
+```
+
+See the [Authentication](authentication.md#self-signed-certificates--tls) page for details and the security caveat.
+
+## "Cannot convert value" cast errors on cmdlet output
+
+Older releases occasionally surfaced cast errors when an API response field type changed between Secret Server versions. v0.62.0 introduced `FilterTssResponse` which mitigates this for the affected endpoints.
+
+**Fix:** upgrade to v0.62.0 or later. See [Installation](install.md).
+
+If the error persists on the latest module against the latest Secret Server, capture a verbose log (next section) and open an issue.
+
+## Capturing a verbose session for bug reports
+
+When opening a GitHub issue, attach a verbose transcript so maintainers can see the full request/response flow:
+
+```powershell
+Start-Transcript -Path .\tss-debug.log
+$VerbosePreference = 'Continue'
+
+# Reproduce the failure
+$session = New-TssSession -SecretServer https://vault.company.com -Credential $cred -Verbose
+Get-TssSecret -TssSession $session -Id 1234 -Verbose
+
+$VerbosePreference = 'SilentlyContinue'
+Stop-Transcript
+```
+
+Redact any tokens, passwords, or secret values from `tss-debug.log` before attaching it to an issue. See the [Logging](logging.md) page for additional log locations.
+
+## Still stuck?
+
+- Check the [CHANGELOG](https://github.com/thycotic-ps/thycotic.secretserver/blob/dev/CHANGELOG.md) for known issues fixed in a later release.
+- Search [existing issues](https://github.com/thycotic-ps/thycotic.secretserver/issues) before filing a new one.
+- Open a new issue with the verbose log attached and the output of `(Get-Module Thycotic.SecretServer).Version`.


### PR DESCRIPTION
## Summary

Phase 1 + 2 of the v0.62.0 documentation refresh (see plan in tracking conversation).

**Phase 1 — install & prerequisites:**
- PSGallery flagged as not updated past 0.60.4 with link to tracking issue #450 from README, install.md, and the docs landing page
- Fix garbled "Windows Powershell PowerShell 7+" prerequisite. PS 7+ is now stated as required for new installs; Windows PowerShell 5.1 remains supported for older module releases (cross-linked to the new Troubleshooting page)
- Add SHA256 integrity verification snippet and an installed-version confirmation snippet
- Add a CHANGELOG release-notes link to the docs landing page

**Phase 2 — authentication & TLS:**
- Document the new ` + "`-SkipCertificateCheck`" + ` switch on ` + "`New-TssSession`" + ` (v0.62.0 RestSharp 112 stopped trusting self-signed certs by default)
- Rename the ` + "`Login-SS`" + ` PowerShell-profile sample to ` + "`Connect-SS`" + ` (approved verb) and add the missing ` + "`-IgnoreDefault`" + ` switch parameter so the existing ` + "`if (-not \$ignoreDefault)`" + ` branch actually does something
- Fix duplicate-verb typo ("creates creating that")
- New ` + "`docs/getting_started/troubleshooting.md`" + ` covering TLS 1.2 on PS 5.1, ` + "`TaskCanceledException`" + ` from self-signed certs, cast errors, and how to capture a verbose session for bug reports

**Out of scope (separate PRs):**
- Phase 3: ` + "`New-TssSession.md`" + ` platyPS regeneration for the ` + "`OtpCode`" + ` int→string fix
- Phase 4: Compatibility matrix update and ` + "`event-pipeline`" + ` folder rename

Refs #450

## Test plan

- [ ] Render the Jekyll site locally (or via GitHub Pages preview) and confirm:
  - [ ] Troubleshooting page appears in the Getting Started nav at order 6
  - [ ] Cross-links between install.md ↔ authentication.md ↔ troubleshooting.md all resolve
  - [ ] Issue #450 link resolves
- [ ] Validate PowerShell snippets in a PS 7 session:
  - [ ] ` + "`Get-FileHash -Algorithm SHA256`" + ` against the published zip
  - [ ] ` + "`New-TssSession -SkipCertificateCheck`" + ` against a self-signed lab Secret Server
  - [ ] ` + "`Connect-SS`" + ` profile sample loads cleanly when sourced into ` + "`\$PROFILE`" + `
- [ ] No broken inbound links from other docs pages (no references to the removed "Direct File Download" anchor)

Generated with [Claude Code](https://claude.com/claude-code)