### PR TITLE
docs: rescue Phase 4 (compat + event-pipeline rename) and switch hash URL to GitHub Releases

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -38,3 +38,4 @@ plugins:
   - jemoji
   - jekyll-avatar
   - jekyll-mentions
+  - jekyll-redirect-from

--- a/docs/commands/event-pipeline-policies/Add-TssEventPipeline.md
+++ b/docs/commands/event-pipeline-policies/Add-TssEventPipeline.md
@@ -2,6 +2,8 @@
 title: Add-TssEventPipeline
 parent: Event Pipeline Policies
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline-policy/Add-TssEventPipeline
 ---
 # Add-TssEventPipeline
 
@@ -118,6 +120,6 @@ Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Add-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Add-TssEventPipeline)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Add-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Add-TssEventPipeline)
 
 [https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Add-TssEventPipeline.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Add-TssEventPipeline.ps1)

--- a/docs/commands/event-pipeline-policies/Disable-TssEventPipelinePolicy.md
+++ b/docs/commands/event-pipeline-policies/Disable-TssEventPipelinePolicy.md
@@ -1,31 +1,33 @@
 ---
-title: Enable-TssEventPipelinePolicy
+title: Disable-TssEventPipelinePolicy
 parent: Event Pipeline Policies
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline-policy/Disable-TssEventPipelinePolicy
 ---
-# Enable-TssEventPipelinePolicy
+# Disable-TssEventPipelinePolicy
 
 ## SYNOPSIS
-Enable an Event Pipeline Policy
+Disable an Event Pipeline Policy
 
 ## SYNTAX
 
 ```
-Enable-TssEventPipelinePolicy [-TssSession] <Session> -Id <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Disable-TssEventPipelinePolicy [-TssSession] <Session> -Id <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Enable an Event Pipeline Policy
+Disable an Event Pipeline Policy
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
 $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
-Enable-TssEventPipelinePolicy -TssSession $session -Id 43
+Disable-TssEventPipelinePolicy -TssSession $session -Id 43
 ```
 
-Enable Event Pipeline Policy 43
+Disable Event Pipeline Policy 43
 
 ## PARAMETERS
 
@@ -45,7 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-Event Pipeline ID to Enable
+Event Pipeline ID to Disable
 
 ```yaml
 Type: Int32[]
@@ -102,6 +104,6 @@ Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Enable-TssEventPipelinePolicy](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Enable-TssEventPipelinePolicy)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Disable-TssEventPipelinePolicy](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Disable-TssEventPipelinePolicy)
 
-[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Enable-TssEventPipelinePolicy.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Enable-TssEventPipelinePolicy.ps1)
+[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Disable-TssEventPipelinePolicy.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Disable-TssEventPipelinePolicy.ps1)

--- a/docs/commands/event-pipeline-policies/Enable-TssEventPipelinePolicy.md
+++ b/docs/commands/event-pipeline-policies/Enable-TssEventPipelinePolicy.md
@@ -1,32 +1,33 @@
 ---
-title: Remove-TssEventPipeline
+title: Enable-TssEventPipelinePolicy
 parent: Event Pipeline Policies
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline-policy/Enable-TssEventPipelinePolicy
 ---
-# Remove-TssEventPipeline
+# Enable-TssEventPipelinePolicy
 
 ## SYNOPSIS
-Remove an Event Pipeline from a specific Event Pipeline Policy
+Enable an Event Pipeline Policy
 
 ## SYNTAX
 
 ```
-Remove-TssEventPipeline [-TssSession] <Session> [-PolicyId] <Int32> [-PipelineId] <Int32[]> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Enable-TssEventPipelinePolicy [-TssSession] <Session> -Id <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Remove an Event Pipeline from a specific Event Pipeline Policy
+Enable an Event Pipeline Policy
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
 $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
-Remove-TssEventPipeline -TssSession $session -PipelineId 42 -PolicyId 3
+Enable-TssEventPipelinePolicy -TssSession $session -Id 43
 ```
 
-Remove Event Pipeline 42 from the Event Pipeline Policy 3
+Enable Event Pipeline Policy 43
 
 ## PARAMETERS
 
@@ -45,33 +46,18 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -PolicyId
-Event Pipeline Policy ID
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases: EventPipelinePolicyId
-
-Required: True
-Position: 2
-Default value: 0
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -PipelineId
-Event Pipeline ID
+### -Id
+Event Pipeline ID to Enable
 
 ```yaml
 Type: Int32[]
 Parameter Sets: (All)
-Aliases: EventPipelineId
+Aliases: EventPipelinePolicyId
 
 Required: True
-Position: 3
+Position: Named
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -118,6 +104,6 @@ Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Remove-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Remove-TssEventPipeline)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Enable-TssEventPipelinePolicy](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Enable-TssEventPipelinePolicy)
 
-[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Remove-TssEventPipeline.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Remove-TssEventPipeline.ps1)
+[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Enable-TssEventPipelinePolicy.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Enable-TssEventPipelinePolicy.ps1)

--- a/docs/commands/event-pipeline-policies/Get-TssEventPipelinePolicy.md
+++ b/docs/commands/event-pipeline-policies/Get-TssEventPipelinePolicy.md
@@ -1,31 +1,33 @@
 ---
-title: Get-TssEventPipelineRun
-parent: Event Pipeline
+title: Get-TssEventPipelinePolicy
+parent: Event Pipeline Policies
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline-policy/Get-TssEventPipelinePolicy
 ---
-# Get-TssEventPipelineRun
+# Get-TssEventPipelinePolicy
 
 ## SYNOPSIS
-Get all of the runs for an Event Pipeline
+Get an Event Pipeline Policy by ID
 
 ## SYNTAX
 
 ```
-Get-TssEventPipelineRun [-TssSession] <Session> -Id <Int32[]> [<CommonParameters>]
+Get-TssEventPipelinePolicy [-TssSession] <Session> -Id <Int32[]> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Get all of the runs for an Event Pipeline
+Get an Event Pipeline Policy by ID
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
 $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
-Get-TssEventPipelineRun -TssSession $session -Id 42
+Get-TssEventPipelinePolicy -TssSession $session -Id 4
 ```
 
-Outputs the Activity details for Event Pipeline 42
+Get Event Pipeline Policy ID 4
 
 ## PARAMETERS
 
@@ -45,12 +47,12 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-Event Pipeline ID
+Event Pipeline Policy ID
 
 ```yaml
 Type: Int32[]
 Parameter Sets: (All)
-Aliases: EventPipelineId
+Aliases: EventPipelinePolicyId
 
 Required: True
 Position: Named
@@ -66,12 +68,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Thycotic.PowerShell.EventPipeline.RunView
+### Thycotic.PowerShell.EventPipelinePolicy.Policy
 ## NOTES
 Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Get-TssEventPipelineRun](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Get-TssEventPipelineRun)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Get-TssEventPipelinePolicy](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Get-TssEventPipelinePolicy)
 
-[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Get-TssEventPipelineRun.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Get-TssEventPipelineRun.ps1)
+[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicy.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicy.ps1)

--- a/docs/commands/event-pipeline-policies/Get-TssEventPipelinePolicyActivity.md
+++ b/docs/commands/event-pipeline-policies/Get-TssEventPipelinePolicyActivity.md
@@ -2,6 +2,8 @@
 title: Get-TssEventPipelinePolicyActivity
 parent: Event Pipeline Policies
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline-policy/Get-TssEventPipelinePolicyActivity
 ---
 # Get-TssEventPipelinePolicyActivity
 
@@ -96,6 +98,6 @@ Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Get-TssEventPipelinePolicyActivity](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Get-TssEventPipelinePolicyActivity)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Get-TssEventPipelinePolicyActivity](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Get-TssEventPipelinePolicyActivity)
 
 [https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicyActivity.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicyActivity.ps1)

--- a/docs/commands/event-pipeline-policies/Remove-TssEventPipeline.md
+++ b/docs/commands/event-pipeline-policies/Remove-TssEventPipeline.md
@@ -1,31 +1,34 @@
 ---
-title: Enable-TssEventPipeline
-parent: Event Pipeline
+title: Remove-TssEventPipeline
+parent: Event Pipeline Policies
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline-policy/Remove-TssEventPipeline
 ---
-# Enable-TssEventPipeline
+# Remove-TssEventPipeline
 
 ## SYNOPSIS
-Enable an Event Pipeline of an Event Pipeline Policy
+Remove an Event Pipeline from a specific Event Pipeline Policy
 
 ## SYNTAX
 
 ```
-Enable-TssEventPipeline [-TssSession] <Session> -Id <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-TssEventPipeline [-TssSession] <Session> [-PolicyId] <Int32> [-PipelineId] <Int32[]> [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Enable an Event Pipeline of an Event Pipeline Policy
+Remove an Event Pipeline from a specific Event Pipeline Policy
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
 $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
-Enable-TssEventPipeline -TssSession $session -Id 43
+Remove-TssEventPipeline -TssSession $session -PipelineId 42 -PolicyId 3
 ```
 
-Enable Event Pipeline 43
+Remove Event Pipeline 42 from the Event Pipeline Policy 3
 
 ## PARAMETERS
 
@@ -44,8 +47,23 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Id
-Event Pipeline ID to enable
+### -PolicyId
+Event Pipeline Policy ID
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: EventPipelinePolicyId
+
+Required: True
+Position: 2
+Default value: 0
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -PipelineId
+Event Pipeline ID
 
 ```yaml
 Type: Int32[]
@@ -53,9 +71,9 @@ Parameter Sets: (All)
 Aliases: EventPipelineId
 
 Required: True
-Position: Named
+Position: 3
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -102,6 +120,6 @@ Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Enable-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Enable-TssEventPipeline)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Remove-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Remove-TssEventPipeline)
 
-[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Enable-TssEventPipeline.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Enable-TssEventPipeline.ps1)
+[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Remove-TssEventPipeline.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Remove-TssEventPipeline.ps1)

--- a/docs/commands/event-pipeline-policies/Search-TssEventPipelinePolicy.md
+++ b/docs/commands/event-pipeline-policies/Search-TssEventPipelinePolicy.md
@@ -2,6 +2,8 @@
 title: Search-TssEventPipelinePolicy
 parent: Event Pipeline Policies
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline-policy/Search-TssEventPipelinePolicy
 ---
 # Search-TssEventPipelinePolicy
 
@@ -156,6 +158,6 @@ Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Search-TssEventPipelinePolicy](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Search-TssEventPipelinePolicy)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Search-TssEventPipelinePolicy](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policies/Search-TssEventPipelinePolicy)
 
 [https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Search-TssEventPipelinePolicy.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Search-TssEventPipelinePolicy.ps1)

--- a/docs/commands/event-pipeline-policies/readme.md
+++ b/docs/commands/event-pipeline-policies/readme.md
@@ -3,6 +3,8 @@ title: Event Pipeline Policies
 parent: Commands
 has_children: true
 nav_order: 21
+redirect_from:
+  - /commands/event-pipeline-policy/
 ---
 
 # Event Pipeline Policies

--- a/docs/commands/event-pipelines/Disable-TssEventPipeline.md
+++ b/docs/commands/event-pipelines/Disable-TssEventPipeline.md
@@ -1,7 +1,9 @@
 ---
 title: Disable-TssEventPipeline
-parent: Event Pipeline
+parent: Event Pipelines
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline/Disable-TssEventPipeline
 ---
 # Disable-TssEventPipeline
 
@@ -102,6 +104,6 @@ Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Disable-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Disable-TssEventPipeline)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Disable-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Disable-TssEventPipeline)
 
 [https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Disable-TssEventPipeline.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Disable-TssEventPipeline.ps1)

--- a/docs/commands/event-pipelines/Enable-TssEventPipeline.md
+++ b/docs/commands/event-pipelines/Enable-TssEventPipeline.md
@@ -1,31 +1,33 @@
 ---
-title: Disable-TssEventPipelinePolicy
-parent: Event Pipeline Policies
+title: Enable-TssEventPipeline
+parent: Event Pipelines
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline/Enable-TssEventPipeline
 ---
-# Disable-TssEventPipelinePolicy
+# Enable-TssEventPipeline
 
 ## SYNOPSIS
-Disable an Event Pipeline Policy
+Enable an Event Pipeline of an Event Pipeline Policy
 
 ## SYNTAX
 
 ```
-Disable-TssEventPipelinePolicy [-TssSession] <Session> -Id <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Enable-TssEventPipeline [-TssSession] <Session> -Id <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Disable an Event Pipeline Policy
+Enable an Event Pipeline of an Event Pipeline Policy
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
 $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
-Disable-TssEventPipelinePolicy -TssSession $session -Id 43
+Enable-TssEventPipeline -TssSession $session -Id 43
 ```
 
-Disable Event Pipeline Policy 43
+Enable Event Pipeline 43
 
 ## PARAMETERS
 
@@ -45,12 +47,12 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-Event Pipeline ID to Disable
+Event Pipeline ID to enable
 
 ```yaml
 Type: Int32[]
 Parameter Sets: (All)
-Aliases: EventPipelinePolicyId
+Aliases: EventPipelineId
 
 Required: True
 Position: Named
@@ -102,6 +104,6 @@ Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Disable-TssEventPipelinePolicy](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Disable-TssEventPipelinePolicy)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Enable-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Enable-TssEventPipeline)
 
-[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Disable-TssEventPipelinePolicy.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Disable-TssEventPipelinePolicy.ps1)
+[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Enable-TssEventPipeline.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Enable-TssEventPipeline.ps1)

--- a/docs/commands/event-pipelines/Get-TssEventPipeline.md
+++ b/docs/commands/event-pipelines/Get-TssEventPipeline.md
@@ -1,31 +1,33 @@
 ---
-title: Get-TssEventPipelinePolicy
-parent: Event Pipeline Policies
+title: Get-TssEventPipeline
+parent: Event Pipelines
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline/Get-TssEventPipeline
 ---
-# Get-TssEventPipelinePolicy
+# Get-TssEventPipeline
 
 ## SYNOPSIS
-Get an Event Pipeline Policy by ID
+Get an Event Pipeline by ID
 
 ## SYNTAX
 
 ```
-Get-TssEventPipelinePolicy [-TssSession] <Session> -Id <Int32[]> [<CommonParameters>]
+Get-TssEventPipeline [-TssSession] <Session> -Id <Int32[]> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Get an Event Pipeline Policy by ID
+Get an Event Pipeline by ID
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
 $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
-Get-TssEventPipelinePolicy -TssSession $session -Id 4
+Get-TssEventPipeline -TssSession $session -Id 43
 ```
 
-Get Event Pipeline Policy ID 4
+Output details on Event Pipeline 43
 
 ## PARAMETERS
 
@@ -50,7 +52,7 @@ Event Pipeline Policy ID
 ```yaml
 Type: Int32[]
 Parameter Sets: (All)
-Aliases: EventPipelinePolicyId
+Aliases: EventPipelineId
 
 Required: True
 Position: Named
@@ -66,12 +68,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Thycotic.PowerShell.EventPipelinePolicy.Policy
+### Thycotic.PowerShell.EventPipeline.List
 ## NOTES
 Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Get-TssEventPipelinePolicy](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline-policy/Get-TssEventPipelinePolicy)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Get-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Get-TssEventPipeline)
 
-[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicy.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline-policy/Get-TssEventPipelinePolicy.ps1)
+[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Get-TssEventPipeline.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Get-TssEventPipeline.ps1)

--- a/docs/commands/event-pipelines/Get-TssEventPipelineRun.md
+++ b/docs/commands/event-pipelines/Get-TssEventPipelineRun.md
@@ -1,31 +1,33 @@
 ---
-title: Get-TssEventPipeline
-parent: Event Pipeline
+title: Get-TssEventPipelineRun
+parent: Event Pipelines
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline/Get-TssEventPipelineRun
 ---
-# Get-TssEventPipeline
+# Get-TssEventPipelineRun
 
 ## SYNOPSIS
-Get an Event Pipeline by ID
+Get all of the runs for an Event Pipeline
 
 ## SYNTAX
 
 ```
-Get-TssEventPipeline [-TssSession] <Session> -Id <Int32[]> [<CommonParameters>]
+Get-TssEventPipelineRun [-TssSession] <Session> -Id <Int32[]> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Get an Event Pipeline by ID
+Get all of the runs for an Event Pipeline
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
 $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
-Get-TssEventPipeline -TssSession $session -Id 43
+Get-TssEventPipelineRun -TssSession $session -Id 42
 ```
 
-Output details on Event Pipeline 43
+Outputs the Activity details for Event Pipeline 42
 
 ## PARAMETERS
 
@@ -45,7 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-Event Pipeline Policy ID
+Event Pipeline ID
 
 ```yaml
 Type: Int32[]
@@ -66,12 +68,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Thycotic.PowerShell.EventPipeline.List
+### Thycotic.PowerShell.EventPipeline.RunView
 ## NOTES
 Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Get-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Get-TssEventPipeline)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Get-TssEventPipelineRun](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Get-TssEventPipelineRun)
 
-[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Get-TssEventPipeline.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Get-TssEventPipeline.ps1)
+[https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Get-TssEventPipelineRun.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Get-TssEventPipelineRun.ps1)

--- a/docs/commands/event-pipelines/Search-TssEventPipeline.md
+++ b/docs/commands/event-pipelines/Search-TssEventPipeline.md
@@ -1,7 +1,9 @@
 ---
 title: Search-TssEventPipeline
-parent: Event Pipeline
+parent: Event Pipelines
 grand_parent: Commands
+redirect_from:
+  - /commands/event-pipeline/Search-TssEventPipeline
 ---
 # Search-TssEventPipeline
 
@@ -158,6 +160,6 @@ Requires TssSession object returned by New-TssSession
 
 ## RELATED LINKS
 
-[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Search-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipeline/Search-TssEventPipeline)
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Search-TssEventPipeline](https://thycotic-ps.github.io/thycotic.secretserver/commands/event-pipelines/Search-TssEventPipeline)
 
 [https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Search-TssEventPipeline.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/event-pipeline/Search-TssEventPipeline.ps1)

--- a/docs/commands/event-pipelines/readme.md
+++ b/docs/commands/event-pipelines/readme.md
@@ -1,10 +1,12 @@
 ---
-title: Event Pipeline
+title: Event Pipelines
 parent: Commands
 has_children: true
 nav_order: 20
+redirect_from:
+  - /commands/event-pipeline/
 ---
 
-# Event Pipeline
+# Event Pipelines
 
 {% include list.liquid all=true %}

--- a/docs/getting_started/compatibility.md
+++ b/docs/getting_started/compatibility.md
@@ -5,11 +5,21 @@ nav_order: 3
 
 # Compatibility
 
-Secret Server REST API was first released with version 9.0. The API has grown since then and continues to grow as the product evolves. The module is tested on the latest Secret Server release available. This page aims to provide a list of endpoints that are only available in specific build versions of Secret Server.
+Secret Server REST API was first released with version 9.0. The API has grown since then and continues to grow as the product evolves. The module is tested through **Secret Server 12.0** as of module v0.62.0. This page lists endpoints that are only available in specific build versions of Secret Server.
 
-> The starting version for maintaining this content will be Secret Server 10.9.
+> The starting version for maintaining this content is Secret Server 10.9.
 
-> Each function included below will have a version check on Secret Server before the endpoint is called.
+> Each function included below has a version check on Secret Server before the endpoint is called.
+
+## Secret Server 12.0 notes
+
+Module v0.62.0 introduced response-filtering fixes for several cmdlets that broke against Secret Server 12.0 when the API added new response fields not yet modeled in the module:
+
+- `Get-TssConfiguration` — handles the SS 12.0 `emailSettings` → `email` property rename and unknown nested fields
+- `Get-TssRpcPasswordType` — pre-coerces nested `fields` array elements before cast
+- `Get-TssDirectoryServiceSyncStatus` — pre-coerces nested `domainStatus` array elements before cast
+
+Other cmdlets received a general response-filtering pass (`FilterTssResponse`) that strips unknown properties before type cast — if you saw `Cannot convert value ... to type Thycotic.PowerShell.<...>` errors on SS 12.0 in older module releases, upgrading to v0.62.0 should resolve them. See [CHANGELOG](https://github.com/thycotic-ps/thycotic.secretserver/blob/dev/CHANGELOG.md) for the full list.
 
 ## Function List
 

--- a/docs/getting_started/compatibility.md
+++ b/docs/getting_started/compatibility.md
@@ -5,21 +5,22 @@ nav_order: 3
 
 # Compatibility
 
-Secret Server REST API was first released with version 9.0. The API has grown since then and continues to grow as the product evolves. The module is tested through **Secret Server 12.0** as of module v0.62.0. This page lists endpoints that are only available in specific build versions of Secret Server.
+Secret Server REST API was first released with version 9.0. The API has grown since then and continues to grow as the product evolves. This page lists endpoints that are only available in specific build versions of Secret Server.
 
 > The starting version for maintaining this content is Secret Server 10.9.
 
 > Each function included below has a version check on Secret Server before the endpoint is called.
 
-## Secret Server 12.0 notes
+## Response handling improvements in 0.62.0
 
-Module v0.62.0 introduced response-filtering fixes for several cmdlets that broke against Secret Server 12.0 when the API added new response fields not yet modeled in the module:
+Secret Server has added and renamed REST response properties across many releases. When the module's typed C# classes don't yet model a newly-added property, cmdlets that cast the response into one of those types fail with `Cannot convert value ... to type Thycotic.PowerShell.<...>`. The errors are not specific to any one Secret Server release — they show up whenever the deployed Secret Server returns fields the module's class definitions don't recognize.
 
-- `Get-TssConfiguration` — handles the SS 12.0 `emailSettings` → `email` property rename and unknown nested fields
-- `Get-TssRpcPasswordType` — pre-coerces nested `fields` array elements before cast
-- `Get-TssDirectoryServiceSyncStatus` — pre-coerces nested `domainStatus` array elements before cast
+Module v0.62.0 addresses this in two ways:
 
-Other cmdlets received a general response-filtering pass (`FilterTssResponse`) that strips unknown properties before type cast — if you saw `Cannot convert value ... to type Thycotic.PowerShell.<...>` errors on SS 12.0 in older module releases, upgrading to v0.62.0 should resolve them. See [CHANGELOG](https://github.com/thycotic-ps/thycotic.secretserver/blob/dev/CHANGELOG.md) for the full list.
+- A general `FilterTssResponse` pass is now applied by all functions before the type cast. Unknown properties are stripped (and reported via `Write-Verbose`) instead of breaking the cast.
+- Three cmdlets received targeted fixes for nested-object cast failures that the general pass alone couldn't handle: `Get-TssConfiguration`, `Get-TssRpcPasswordType`, and `Get-TssDirectoryServiceSyncStatus`.
+
+If you've been seeing `Cannot convert value` errors on older module releases, upgrading to v0.62.0 should resolve them regardless of which Secret Server version you're running. See [CHANGELOG](https://github.com/thycotic-ps/thycotic.secretserver/blob/dev/CHANGELOG.md) for the full list of fixes.
 
 ## Function List
 

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -62,13 +62,17 @@ There are multiple options for downloading the module files:
 
 ### Integrity verification
 
-The published SHA256 hash for each release is at [thycotic.secretserver_hash.txt](https://thyproservices.z20.web.core.windows.net/Thycotic.SecretServer_hash.txt). Verify the downloaded zip before extracting:
+Each GitHub Release includes a `Thycotic.SecretServer_hash.txt` asset with the SHA256 of that release's zip. For v0.62.0:
+
+- https://github.com/thycotic-ps/thycotic.secretserver/releases/download/v0.62.0/Thycotic.SecretServer_hash.txt
+
+For other releases, browse to the [Releases page](https://github.com/thycotic-ps/thycotic.secretserver/releases) and grab the hash asset attached to that release. Verify your downloaded zip:
 
 ```powershell
 Get-FileHash -Algorithm SHA256 .\Thycotic.SecretServer.zip
 ```
 
-Compare the output to the hash file above.
+Compare the output to the contents of the hash file.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

PR #453 (Phase 4 of the v0.62.0 docs refresh) merged into the now-closed `jagger/docs-refresh-v0.62.0` feature branch instead of `dev`, so its content never landed on dev. This PR re-applies that work on top of current dev, plus fixes the dead hash URL flagged in #456.

**Re-landing from PR #453:**
- `docs/getting_started/compatibility.md` — reframed the 0.62.0 response-handling fixes (general `FilterTssResponse` pass + three targeted nested-object cmdlets) as version-agnostic; the cast failures aren't SS 12.0-specific
- Folder rename: `docs/commands/event-pipeline/` → `event-pipelines/`, `event-pipeline-policy/` → `event-pipeline-policies/` to match plural sibling folders (`secrets/`, `folders/`, `reports/`, etc.)
- Every moved page gets `redirect_from:` frontmatter pointing at its old URL; self-links inside RELATED LINKS updated to the new path
- Added `jekyll-redirect-from` plugin to `docs/_config.yml` so redirects actually render

**New — hash URL fix (#456):**
- The previously-published hash file at `https://thyproservices.z20.web.core.windows.net/Thycotic.SecretServer_hash.txt` no longer resolves (DNS NXDOMAIN)
- The v0.62.0 GitHub Release already attaches `Thycotic.SecretServer_hash.txt` as a release asset; the same pattern is the recommended path going forward
- `docs/getting_started/install.md` integrity-verification snippet now points at the v0.62.0 release asset directly and tells users to grab the hash from the Releases page for other versions

Closes #456.

## Verification

- `grep -rn "thyproservices" docs/ README.md` returns no matches.
- Verified the v0.62.0 GitHub Release `Thycotic.SecretServer_hash.txt` content matches the SHA256 of the CDN-distributed zip exactly:
  `fbf3ab0ea1cf74b20a751b29e2526a9e7acef0a4b698864944a5715ce8b07b6b`

Generated with [Claude Code](https://claude.com/claude-code)
