### PR TITLE
fix: strip trailing whitespace from Get-TssSecret.ps1 (#462)

### DIFF
--- a/src/functions/secrets/Get-TssSecret.ps1
+++ b/src/functions/secrets/Get-TssSecret.ps1
@@ -94,7 +94,7 @@ function Get-TssSecret {
         [Parameter(ParameterSetName = 'path')]
         [Parameter(ParameterSetName = 'restricted')]
         [string]$Comment,
-                
+
 
         # Double lock password, provie as a secure string
         [Parameter(ParameterSetName = 'id')]
@@ -150,11 +150,11 @@ function Get-TssSecret {
                 Compare-TssVersion $TssSession '11.0.000000' $PSCmdlet.MyInvocation
                 foreach ($p in $Path) {
                     $restResponse = $null
-                    $queryParams = @() 
+                    $queryParams = @()
                     $uri = $TssSession.ApiUrl, 'secrets', 0 -join '/'
-                    
+
                     $queryParams += @("secretPath=$p")
-                    
+
                     $getBody = @{}
                     if ($restrictedParams.Count -gt 0) {
                         switch ($tssParams.Keys) {


### PR DESCRIPTION
## Summary

Four lines in `src/functions/secrets/Get-TssSecret.ps1` (97, 153, 155, 157) carried trailing spaces that fail `Module.FileIntegrity.Tests.ps1` with `Should have no trailing space`.

No source-code behavior change. Pure cleanup.

Closes #462.

## Test plan

- [x] `grep -nE ' +$' src/functions/secrets/Get-TssSecret.ps1` returns no matches
- [ ] `Module.FileIntegrity.Tests.ps1` passes for this file (validated locally before push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)