### PR TITLE
fix: add .EXAMPLE blocks to New-TssUser CBH (#463)

### DIFF
--- a/src/functions/users/New-TssUser.ps1
+++ b/src/functions/users/New-TssUser.ps1
@@ -6,6 +6,20 @@ function New-TssUser {
     .DESCRIPTION
     Create a new Secret Server User
 
+    .EXAMPLE
+    $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
+    $password = Read-Host -AsSecureString -Prompt 'New user password'
+    New-TssUser -TssSession $session -Username 'jdoe' -DisplayName 'Jane Doe' -EmailAddress 'jane@example.com' -Password $password -Active
+
+    Create a local Secret Server user 'jdoe' with the provided password and an enabled account.
+
+    .EXAMPLE
+    $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
+    $password = ConvertTo-SecureString 'StrongPwd!' -AsPlainText -Force
+    New-TssUser -TssSession $session -Username 'svcAccount' -DisplayName 'Service Account' -Password $password -IsApplicationAccount
+
+    Create an application account (used for API integrations) with a pre-set password.
+
     .LINK
     https://thycotic-ps.github.io/thycotic.secretserver/commands/users/New-TssUser
 


### PR DESCRIPTION
## Summary

`Module.Help.Tests.ps1` enforces that every exported function ships with at least one `.EXAMPLE`. `New-TssUser` had none. Added two examples covering the two main creation flows (local user with prompted securestring, application account with pre-set password).

CBH style follows the sibling `src/functions/users/Update-TssUser.ps1`.

No source-code behavior change.

Closes #463.

## Test plan

- [x] `grep -c "\.EXAMPLE" src/functions/users/New-TssUser.ps1` returns 2
- [ ] `Module.Help.Tests.ps1` no longer reports `Testing New-TssUser.Should have an Example` as a failure (validated locally before push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)