### PR TITLE
docs: clarify Get-TssGroupUser vs Get-TssGroupMember use cases (#434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### General Updates
 
 * `[OutputType]` declarations corrected on 70+ cmdlets where the function emits an array (`[Type[]]` cast) but the metadata declared singular `[Type]`. Get-Help and IntelliSense now report the correct collection contract for cmdlets including `Get-TssFolder`, `Search-TssGroup`, `Search-TssUser`, `Get-TssSecretAudit`, and others.
+* `Get-TssGroupUser` / `Get-TssGroupMember` - clarified help, synopsis, parameter descriptions, and the failure warning to distinguish their use cases: `Get-TssGroupUser` targets a single, specific user within a Group (`-UserId` is mandatory), while `Get-TssGroupMember` lists all members of a Group. The two commands now cross-reference each other in their `.LINK`/RELATED LINKS. No interface change (rename avoided to prevent a breaking change). Fixes #434.
 
 ### Tests
 

--- a/docs/commands/groups/Get-TssGroupMember.md
+++ b/docs/commands/groups/Get-TssGroupMember.md
@@ -6,7 +6,7 @@ grand_parent: Commands
 # Get-TssGroupMember
 
 ## SYNOPSIS
-Get a Group's membership
+Get all users that are members of a Group
 
 ## SYNTAX
 
@@ -16,7 +16,9 @@ Get-TssGroupMember [-TssSession] <Session> -Id <Int32[]> [-IncludeInactive] [-Us
 ```
 
 ## DESCRIPTION
-Get a Group's membership
+Get a Group's membership - lists all users that are members of the given Group, with optional filtering (inactive users, user domain) and sorting.
+
+To get the details of a single, specific user within a Group, use [Get-TssGroupUser](Get-TssGroupUser) instead.
 
 ## EXAMPLES
 
@@ -116,8 +118,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 Requires TssSession object returned by New-TssSession
 
+This command lists all members of a Group via the groups/{id}/users endpoint.
+To target a single user within a Group use Get-TssGroupUser.
+
 ## RELATED LINKS
 
 [https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupMember](https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupMember)
 
 [https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/groups/TssGet-GroupMember.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/groups/TssGet-GroupMember.ps1)
+
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupUser](https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupUser)

--- a/docs/commands/groups/Get-TssGroupUser.md
+++ b/docs/commands/groups/Get-TssGroupUser.md
@@ -6,7 +6,7 @@ grand_parent: Commands
 # Get-TssGroupUser
 
 ## SYNOPSIS
-Get a user in a Group
+Get a specific user's membership in a Group
 
 ## SYNTAX
 
@@ -15,7 +15,10 @@ Get-TssGroupUser [-TssSession] <Session> -Id <Int32> -UserId <Int32> [<CommonPar
 ```
 
 ## DESCRIPTION
-Get a user in a Group
+Get the details of a single, specific user within a Group.
+Both the Group ID (-Id) and the User ID (-UserId) are required; this command verifies and returns one user's membership in the given Group.
+
+To list ALL users that are members of a Group, use [Get-TssGroupMember](Get-TssGroupMember) instead.
 
 ## EXAMPLES
 
@@ -26,6 +29,14 @@ Get-TssGroupUser -TssSession $session -Id 8 -UserId 43
 ```
 
 Get User Id 43 details in Group ID 8
+
+### EXAMPLE 2
+```
+$session = New-TssSession -SecretServer https://alpha -Credential $ssCred
+Get-TssGroupMember -TssSession $session -Id 8
+```
+
+To list every member of a Group, use Get-TssGroupMember (not Get-TssGroupUser, which targets a single user)
 
 ## PARAMETERS
 
@@ -60,7 +71,8 @@ Accept wildcard characters: False
 ```
 
 ### -UserId
-User ID
+User ID of the specific user to look up within the Group.
+Mandatory; to list all members of a Group use Get-TssGroupMember.
 
 ```yaml
 Type: Int32
@@ -85,8 +97,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 Requires TssSession object returned by New-TssSession
 
+This command targets a single user via the groups/{id}/users/{userId} endpoint, so -UserId is mandatory.
+To enumerate all members of a Group use Get-TssGroupMember.
+
 ## RELATED LINKS
 
 [https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupUser](https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupUser)
 
 [https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/groups/Get-TssGroupUser.ps1](https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/groups/Get-TssGroupUser.ps1)
+
+[https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupMember](https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupMember)

--- a/src/functions/groups/Get-TssGroupMember.ps1
+++ b/src/functions/groups/Get-TssGroupMember.ps1
@@ -1,10 +1,13 @@
 function Get-TssGroupMember {
     <#
     .SYNOPSIS
-    Get a Group's membership
+    Get all users that are members of a Group
 
     .DESCRIPTION
-    Get a Group's membership
+    Get a Group's membership - lists all users that are members of the given Group, with optional
+    filtering (inactive users, user domain) and sorting.
+
+    To get the details of a single, specific user within a Group, use Get-TssGroupUser instead.
 
     .EXAMPLE
     $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
@@ -18,8 +21,14 @@ function Get-TssGroupMember {
     .LINK
     https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/groups/TssGet-GroupMember.ps1
 
+    .LINK
+    https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupUser
+
     .NOTES
     Requires TssSession object returned by New-TssSession
+
+    This command lists all members of a Group via the groups/{id}/users endpoint.
+    To target a single user within a Group use Get-TssGroupUser.
     #>
     [CmdletBinding()]
     [OutputType('Thycotic.PowerShell.Groups.UserSummary[]')]

--- a/src/functions/groups/Get-TssGroupUser.ps1
+++ b/src/functions/groups/Get-TssGroupUser.ps1
@@ -1,10 +1,13 @@
 function Get-TssGroupUser {
     <#
     .SYNOPSIS
-    Get a user in a Group
+    Get a specific user's membership in a Group
 
     .DESCRIPTION
-    Get a user in a Group
+    Get the details of a single, specific user within a Group. Both the Group ID (-Id) and the User ID
+    (-UserId) are required; this command verifies and returns one user's membership in the given Group.
+
+    To list ALL users that are members of a Group, use Get-TssGroupMember instead.
 
     .EXAMPLE
     $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
@@ -12,14 +15,26 @@ function Get-TssGroupUser {
 
     Get User Id 43 details in Group ID 8
 
+    .EXAMPLE
+    $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
+    Get-TssGroupMember -TssSession $session -Id 8
+
+    To list every member of a Group, use Get-TssGroupMember (not Get-TssGroupUser, which targets a single user)
+
     .LINK
     https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupUser
 
     .LINK
     https://github.com/thycotic-ps/thycotic.secretserver/blob/main/src/functions/groups/Get-TssGroupUser.ps1
 
+    .LINK
+    https://thycotic-ps.github.io/thycotic.secretserver/commands/groups/Get-TssGroupMember
+
     .NOTES
     Requires TssSession object returned by New-TssSession
+
+    This command targets a single user via the groups/{id}/users/{userId} endpoint, so -UserId is mandatory.
+    To enumerate all members of a Group use Get-TssGroupMember.
     #>
     [CmdletBinding()]
     [OutputType('Thycotic.PowerShell.Groups.User')]
@@ -35,7 +50,7 @@ function Get-TssGroupUser {
         [int]
         $Id,
 
-        # User ID
+        # User ID of the specific user to look up within the Group. Mandatory; to list all members of a Group use Get-TssGroupMember.
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [int]
         $UserId
@@ -58,7 +73,7 @@ function Get-TssGroupUser {
                 $apiResponse = Invoke-TssApi @invokeParams
                 $restResponse = . $ProcessResponse $apiResponse
             } catch {
-                Write-Warning "Issue getting User [$UserId] on Group [$Id"
+                Write-Warning "Issue getting User [$UserId] on Group [$Id]. To list all members of a Group, use Get-TssGroupMember instead."
                 $err = $_
                 . $ErrorHandling $err
             }


### PR DESCRIPTION
## Summary

Resolves the confusion reported in #434: `Get-TssGroupUser` requires **both** `-Id` and `-UserId`, but its name implied it would list all users in a group — so users hit `Cannot process command because of one or more missing mandatory parameters: UserId` and assumed the cmdlet was broken.

Renaming the cmdlet was rejected as a **breaking change**. Instead this PR clarifies the two cmdlets' distinct purposes everywhere a user would look (Get-Help, IntelliSense, runtime warning, docs), with no interface change.

## Changes

- **`Get-TssGroupUser`** — synopsis/description now state it targets a *single, specific* user within a Group; `-UserId` parameter help clarified as mandatory; failure `Write-Warning` now points to `Get-TssGroupMember` (and fixes a pre-existing missing-`]` typo in that message).
- **`Get-TssGroupMember`** — synopsis/description now state it lists *all* members of a Group.
- Both cmdlets and their docs **cross-reference each other** via `.LINK` / RELATED LINKS.
- `CHANGELOG.md` entry added under **0.62.1 → General Updates**.

## Why not make `-UserId` optional?

The "list all members of a group" need is already fully served by `Get-TssGroupMember` (which also supports `-IncludeInactive`, `-UserDomainId`, `-SortBy`, paging, and multiple group IDs). Making `-UserId` optional would create two cmdlets doing the same job. Clarifying the docs keeps each cmdlet single-purpose.

## Notes

- The exact error string in the issue is generated by PowerShell's own mandatory-parameter handling and can't be customized without making `-UserId` optional; this PR instead clarifies it in help, IntelliSense, and the failure warning.
- Documentation/help-text only — no behavioral change. `release_dir/` copies are build outputs and were intentionally left untouched.

Fixes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
