### PR TITLE
fix: Get-TssSecretField uses ConvertFrom-Json for value decoding (#370, #336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `Search-TssSecret` - fix `Cannot convert "System.Object[]" to type Thycotic.PowerShell.Secrets.Summary` when assigning the result to a typed receiver against folders with multiple secrets. The cmdlet now uses the unary comma operator to preserve the typed array across PowerShell's pipeline unrolling. Fixes #459.
 * `New-TssSecretPermission` - fix `API_GenericException: The server was unable to determine which SecretAccessRole to use` when granting any access to a secret. The cmdlet was building the JSON body with PascalCase keys (`SecretAccessRoleName`, `SecretId`, `Username`, `GroupName`) while Secret Server's REST API expects camelCase (matching what `Update-TssSecretPermission` and `New-TssFolderPermission` already use). All four keys lowered, both user-grant and group-grant paths now succeed. Fixes #326.
+* `Get-TssSecretField` - fix two long-standing field-value handling bugs. The cmdlet previously stripped the API response's outer quotes with `Substring(1, length-2)`, which crashed with `startIndex cannot be larger than length of string` when the field value was empty (#370) and left backslash-escaped quotes (`\"`) embedded in returned passwords that contained quote characters (#336). The Substring trim is replaced with `ConvertFrom-Json`, which handles outer-quote stripping, all JSON backslash escapes (`\"`, `\\`, `\n`, `\uXXXX`), and the empty-content boundary case. Fixes #370, #336.
 
 ### General Updates
 

--- a/src/functions/secrets/Get-TssSecretField.ps1
+++ b/src/functions/secrets/Get-TssSecretField.ps1
@@ -157,11 +157,17 @@ function Get-TssSecretField {
                 try {
                     $apiResponse = Invoke-TssApi @invokeParams
                     if (-not $tssParams.ContainsKey('OutFile')) {
-						$content = $apiResponse.Content
-						$apiResponse.Content = $content.Substring(1,$content.Length-2)
+                        # Field-value endpoint returns a JSON-encoded scalar string.
+                        # ConvertFrom-Json handles outer-quote stripping, backslash escapes
+                        # (\", \\, \n, \uXXXX), and the empty-content boundary case.
+                        # Replaces a Substring(1, length-2) approach that crashed on empty
+                        # content (#370) and left escapes in the result (#336).
+                        if ($apiResponse.Content) {
+                            $apiResponse.Content = $apiResponse.Content | ConvertFrom-Json
+                        }
                         . $ProcessResponse $apiResponse
                     }
-                }catch {
+                } catch {
                     Write-Warning "Issue getting field [$Slug] on secret [$secret]"
                     $err = $_
                     . $ErrorHandling $err


### PR DESCRIPTION
## Summary

The `/secrets/{id}/fields/{slug}` endpoint returns a JSON-encoded scalar string. `Get-TssSecretField` previously stripped the outer quotes with `Substring(1, content.Length - 2)`, which failed two ways:

- On empty content (length 0), `Substring(1, -2)` threw `startIndex cannot be larger than length of string` (#370).
- On values containing embedded quotes (e.g. password `Im"P@ss"word` serialised by the API as `"Im\"P@ss\"word"`), the Substring left the backslash escapes in the returned string (#336).

The Substring is replaced with `ConvertFrom-Json`, which handles outer-quote stripping, every JSON backslash escape (`\"`, `\\`, `\n`, `\uXXXX`), and the empty-content boundary case. The empty path is guarded so `ProcessResponse` still receives the empty string as before.

Closes #370.
Closes #336.

## Behavior matrix

| Field value | Response body | Before fix | After fix |
|---|---|---|---|
| `MyPassword` | `"MyPassword"` | `MyPassword` ✓ | `MyPassword` ✓ |
| `Im"P@ss"word` | `"Im\"P@ss\"word"` | `Im\"P@ss\"word` ✗ (#336) | `Im"P@ss"word` ✓ |
| `path\to\thing` | `"path\\to\\thing"` | `path\\to\\thing` ✗ | `path\to\thing` ✓ |
| *(empty)* | `""` | empty string ✓ | empty string ✓ |
| *(blank body)* | `` (length 0) | **throws** (#370) | empty string, no throw ✓ |

## Test plan

- [x] Lab against Secret Server 12.x — covered 4 scenarios with real secrets (normal, embedded-quote, backslash, empty notes field). All match expected.
- [x] No CBH regression — comment-based help untouched, `Module.Help.Tests.ps1` unaffected.
- [ ] No new test added — the existing test pattern in `tests/secrets/Get-TssSecretField.Tests.ps1` is metadata-only (parameter set + OutputType). Adding mocked-response coverage is a larger pattern change; flagged as a follow-up if desired.

## Release

Targets v0.62.1 (already drafted in CHANGELOG on `dev`). Bug-fix-only change, no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)