### PR TITLE
fix: Start-TssSecretChangePassword defaults -Type to 'Random' (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `[OutputType]` declarations corrected on 70+ cmdlets where the function emits an array (`[Type[]]` cast) but the metadata declared singular `[Type]`. Get-Help and IntelliSense now report the correct collection contract for cmdlets including `Get-TssFolder`, `Search-TssGroup`, `Search-TssUser`, `Get-TssSecretAudit`, and others.
 * `Get-TssGroupUser` / `Get-TssGroupMember` - clarified help, synopsis, parameter descriptions, and the failure warning to distinguish their use cases: `Get-TssGroupUser` targets a single, specific user within a Group (`-UserId` is mandatory), while `Get-TssGroupMember` lists all members of a Group. The two commands now cross-reference each other in their `.LINK`/RELATED LINKS. No interface change (rename avoided to prevent a breaking change). Fixes #434.
+* `Start-TssSecretChangePassword` - `-Type` no longer mandatory; defaults to `Random`. The most common call - an immediate random password rotation - is now `Start-TssSecretChangePassword -TssSession $s -Id $id` without the explicit `-Type Random`. `-Type Manual` with `-NextPassword` still works for caller-supplied passwords. Validation messages for missing/conflicting `-NextPassword` are unchanged. Fixes #444.
 
 ### Tests
 

--- a/src/functions/secrets/Start-TssSecretChangePassword.ps1
+++ b/src/functions/secrets/Start-TssSecretChangePassword.ps1
@@ -10,7 +10,15 @@ function Start-TssSecretChangePassword {
     $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
     Start-TssSecretChangePassword -TssSession $session -Id 46
 
-    Start a current password change operation on secret 46
+    Start an immediate random password rotation on secret 46. The default for
+    -Type is 'Random' when not specified.
+
+    .EXAMPLE
+    $session = New-TssSession -SecretServer https://alpha -Credential $ssCred
+    $secure = Read-Host -AsSecureString -Prompt 'New password'
+    Start-TssSecretChangePassword -TssSession $session -Id 46 -Type Manual -NextPassword $secure
+
+    Rotate secret 46 to a caller-supplied password.
 
     .LINK
     https://thycotic-ps.github.io/thycotic.secretserver/commands/secrets/Start-TssSecretChangePassword
@@ -34,11 +42,10 @@ function Start-TssSecretChangePassword {
         [int[]]
         $Id,
 
-        # Next Password Type, allowed Manual or Random
-        [Parameter(Mandatory)]
+        # Next Password Type, allowed Manual or Random. Defaults to Random.
         [ValidateSet('Manual', 'Random')]
         [string]
-        $Type,
+        $Type = 'Random',
 
         # Manual Next Password to use
         [securestring]


### PR DESCRIPTION
## Summary

Removes `[Parameter(Mandatory)]` from `-Type` and sets its default to `'Random'`. The most common call - an immediate random password rotation - is now:

```powershell
Start-TssSecretChangePassword -TssSession $s -Id 46
```

instead of the previously required `-Type Random` boilerplate.

Adds a second `.EXAMPLE` showing the Manual-with-supplied-password path so the non-default usage is still easy to find.

Closes #444.

## Behavior matrix

Unchanged from what the issue requested:

| `-Type` | `-NextPassword` | Result |
|---|---|---|
| *(omitted)* | *(omitted)* | **Random rotation (new default)** |
| `Random` | *(omitted)* | Random rotation (explicit, same as before) |
| `Manual` | provided | Manual rotation |
| `Manual` | *(omitted)* | Error: `-NextPassword required` (unchanged) |
| `Random` | provided | Error: `-NextPassword cannot be used with Random` (unchanged) |

## Lab verification

Against Secret Server 12.x:

```
=== Call without -Type (should default to Random) ===
POST .../internals/secret-detail/86509/change-password-now with:
  { "data": { "PasswordType": 0, "NextPassword": null } }
Password Change successfully started on Secret [86509]

=== Call with -Type Manual but no -NextPassword (should error gracefully) ===
-NextPassword parameter must be provided when using PasswordType of [Manual]
```

Both paths behave as specified.

## Release

Targets v0.62.1 (on the 0.62.1 milestone). UX change with no API surface removal - callers who were explicitly passing `-Type Random` continue to work identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)