### PR TITLE
fix: New-TssSecretPermission uses camelCase JSON body keys (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * `Search-TssSecret` - fix `Cannot convert "System.Object[]" to type Thycotic.PowerShell.Secrets.Summary` when assigning the result to a typed receiver against folders with multiple secrets. The cmdlet now uses the unary comma operator to preserve the typed array across PowerShell's pipeline unrolling. Fixes #459.
+* `New-TssSecretPermission` - fix `API_GenericException: The server was unable to determine which SecretAccessRole to use` when granting any access to a secret. The cmdlet was building the JSON body with PascalCase keys (`SecretAccessRoleName`, `SecretId`, `Username`, `GroupName`) while Secret Server's REST API expects camelCase (matching what `Update-TssSecretPermission` and `New-TssFolderPermission` already use). All four keys lowered, both user-grant and group-grant paths now succeed. Fixes #326.
 
 ### General Updates
 

--- a/src/functions/secret-permissions/New-TssSecretPermission.ps1
+++ b/src/functions/secret-permissions/New-TssSecretPermission.ps1
@@ -84,13 +84,13 @@ function New-TssSecretPermission {
                     $invokeParams.Method = 'POST'
 
                     $newBody = [ordered]@{
-                        SecretAccessRoleName = [string]$AccessRole
-                        SecretId             = $secret
+                        secretAccessRoleName = [string]$AccessRole
+                        secretId             = $secret
                     }
                     switch ($tssNewParams.Keys) {
                         'DomainName' { $newBody.Add('domainName', $DomainName) }
-                        'Username' { $newBody.Add('Username', $Username) }
-                        'GroupName' { $newBody.Add('GroupName', $GroupName) }
+                        'Username' { $newBody.Add('username', $Username) }
+                        'GroupName' { $newBody.Add('groupName', $GroupName) }
                     }
                     $invokeParams.Body = ($newBody | ConvertTo-Json)
 


### PR DESCRIPTION
## Summary

`POST /secret-permissions` was failing with:

```
API_GenericException: The server was unable to determine which SecretAccessRole to use.
Please provide a valid SecretAccessRoleName if using REST. Otherwise, make sure your
request has a valid SecretAccessRoleID.
```

The cmdlet was sending PascalCase JSON keys (`SecretAccessRoleName`, `SecretId`, `Username`, `GroupName`) but Secret Server's REST API expects camelCase. `Update-TssSecretPermission` (the sibling at `PUT /secret-permissions/{id}`) and `New-TssFolderPermission` (the parallel working cmdlet) already use camelCase. The drift looks like a missed update when `-AccessRole` was converted to an enum.

Four key renames in the `[ordered]` body and the switch block:

| Before (PascalCase) | After (camelCase) |
|---|---|
| `SecretAccessRoleName` | `secretAccessRoleName` |
| `SecretId` | `secretId` |
| `Username` | `username` |
| `GroupName` | `groupName` |

No PowerShell parameter names change. The cmdlet's public surface is unchanged.

Closes #326.

## Lab verification

Against Secret Server 12.x. Two paths exercised, both pass:

```
=== Path 1: group-based grant (Edit to team_executive) ===
  group grant:
    grant call returned: id=180014, role=Edit
    Search-TssSecretPermission shows role 'Edit' present: PASS

=== Path 2: user-based grant (View to local claude) ===
  user grant:
    grant call returned: id=180013, role=View
    Search-TssSecretPermission shows role 'View' present: PASS
```

`Search-TssSecretPermission` round-trips both roles correctly.

## Release

Targets v0.62.1 (on the 0.62.1 milestone). Bug-fix-only change, no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)